### PR TITLE
Making Tag-Type Non-optional

### DIFF
--- a/src/lib/components/TagsSelection.svelte
+++ b/src/lib/components/TagsSelection.svelte
@@ -10,7 +10,7 @@
 		tags?.length
 			? tagList
 					.filter((tag) => tags.includes(String(tag.id)))
-					.map((tag) => tag.name + '-(' + tag.tag_type.name + ')')
+					.map((tag) => tag.name + (tag.tag_type ? '-(' + tag.tag_type.name + ')' : ''))
 			: 'Select relevant tags'
 	);
 </script>
@@ -37,7 +37,10 @@
 		<Select.Group>
 			<Select.GroupHeading>Select Relavant Tags</Select.GroupHeading>
 			{#each tagList as tag}
-				<Select.Item value={String(tag.id)} label={tag.name + '-(' + tag.tag_type.name + ')'} />
+				<Select.Item
+					value={String(tag.id)}
+					label={tag.name + (tag.tag_type ? '-(' + tag.tag_type.name + ')' : '')}
+				/>
 			{/each}
 		</Select.Group>
 	</Select.Content>

--- a/src/routes/(admin)/questionbank/single-question/[id]/Tag.svelte
+++ b/src/routes/(admin)/questionbank/single-question/[id]/Tag.svelte
@@ -6,7 +6,6 @@
 	import { superForm, type Infer, type SuperValidated } from 'sveltekit-superforms';
 	import { tagSchema, type TagFormSchema } from './schema';
 	import { zodClient } from 'sveltekit-superforms/adapters';
-	import * as Alert from '$lib/components/ui/alert/index.js';
 	let {
 		tagTypes,
 		form,
@@ -37,7 +36,7 @@
 		validators: zodClient(tagSchema),
 		dataType: 'json',
 		onSubmit: () => {
-			$formTagData.tag_type_id = String($formTagData.tag_type_id);
+			$formTagData.tag_type_id = $formTagData.tag_type_id;
 		}
 	});
 </script>
@@ -53,6 +52,14 @@
 				placeholder="Enter a tag name"
 				name="name"
 				bind:value={$formTagData.name}
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<h2 class="font-semibold">Tag Description</h2>
+			<Textarea
+				placeholder="Enter the description here..."
+				name="description"
+				bind:value={$formTagData.description}
 			/>
 		</div>
 		<div class="flex w-full flex-col gap-2">
@@ -72,19 +79,12 @@
 				</Select.Content>
 			</Select.Root>
 		</div>
-		<div class="flex flex-col gap-2">
-			<h2 class="font-semibold">Tag Description</h2>
-			<Textarea
-				placeholder="Enter the description here..."
-				name="description"
-				bind:value={$formTagData.description}
-			/>
-		</div>
+
 		<div class="my-4 flex flex-row justify-end gap-4">
 			<Button type="button" variant="outline" class="text-primary" onclick={() => (open = false)}
 				>Cancel</Button
 			>
-			<Button type="submit" disabled={!$formTagData.name || !$formTagData.tag_type_id}>Save</Button>
+			<Button type="submit" disabled={!$formTagData.name}>Save</Button>
 		</div>
 	</div>
 </form>

--- a/src/routes/(admin)/questionbank/single-question/[id]/schema.ts
+++ b/src/routes/(admin)/questionbank/single-question/[id]/schema.ts
@@ -1,37 +1,34 @@
 import { z } from 'zod';
 
-
 export const optionSchema = z.object({
-    id: z.number().int(),
-    key: z.string(),
-    value: z.string()
+	id: z.number().int(),
+	key: z.string(),
+	value: z.string()
 });
 
 export const questionSchema = z.object({
-        question_text: z.string().nonempty({ message: "Question text is required" }),
-        instructions: z.string().nullable().optional(),
-        question_type: z.enum(["single-choice", "multi-choice"]).default("single-choice"),
-        options: z.array(optionSchema).min(2).default([]),
-        correct_answer: z.array(z.number().int()).min(1).default([]),
-        subjective_answer_limit: z.number().int().positive().nullable().optional(),
-        is_mandatory: z.boolean().default(false),
-        solution: z.string().nullable().optional(),
-        organization_id: z.number().int().positive(),
-        state_ids: z.array(z.string()).default([]),
-        district_ids: z.array(z.string()).default([]),
-        block_ids: z.array(z.string()).default([]),
-        tag_ids: z.array(z.string()).default([]),
-        is_active: z.boolean().default(true),
+	question_text: z.string().nonempty({ message: 'Question text is required' }),
+	instructions: z.string().nullable().optional(),
+	question_type: z.enum(['single-choice', 'multi-choice']).default('single-choice'),
+	options: z.array(optionSchema).min(2).default([]),
+	correct_answer: z.array(z.number().int()).min(1).default([]),
+	subjective_answer_limit: z.number().int().positive().nullable().optional(),
+	is_mandatory: z.boolean().default(false),
+	solution: z.string().nullable().optional(),
+	organization_id: z.number().int().positive(),
+	state_ids: z.array(z.string()).default([]),
+	district_ids: z.array(z.string()).default([]),
+	block_ids: z.array(z.string()).default([]),
+	tag_ids: z.array(z.string()).default([]),
+	is_active: z.boolean().default(true)
 });
 
 export type FormSchema = typeof questionSchema;
 
-
-
 export const tagSchema = z.object({
-    description: z.string().nullable().optional(),
-    name: z.string().nonempty({ message: "Tag name is required" }),
-    tag_type_id: z.string(),
+	description: z.string().nullable().optional(),
+	name: z.string().nonempty({ message: 'Tag name is required' }),
+	tag_type_id: z.number().nullable().default(null).optional()
 });
 
 export type TagFormSchema = typeof tagSchema;


### PR DESCRIPTION
Fixes #58 

While creating and listing tags, its association with tag-types should be optional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag label display to safely handle cases where tag types may be missing.
  * Fixed form layout by removing duplicate "Tag Description" fields and repositioning the input.

* **Style**
  * Updated formatting for consistency in error messages and enum definitions.

* **New Features**
  * The tag type selection is now optional when creating or editing tags.

* **Refactor**
  * Simplified form validation and button enablement logic for tag creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->