### PR TITLE
fix: handle dialog message after bulk upload

### DIFF
--- a/src/routes/(admin)/questionbank/import/+page.server.ts
+++ b/src/routes/(admin)/questionbank/import/+page.server.ts
@@ -46,6 +46,6 @@ export const actions = {
 		}
 
 		const data = await response.json();
-		return message(form, data.message || 'File uploaded successfully');
+		return message(form, data);
 	}
 };

--- a/src/routes/(admin)/questionbank/import/+page.svelte
+++ b/src/routes/(admin)/questionbank/import/+page.svelte
@@ -76,6 +76,7 @@
 				<a
 					href={$message.failed_question_details.split(': ')[1]}
 					class="text-primary inline-flex items-center gap-2 font-medium"
+					download="error_report.csv"
 				>
 					<Download size={16} />
 					Download error report

--- a/src/routes/(admin)/questionbank/import/+page.svelte
+++ b/src/routes/(admin)/questionbank/import/+page.svelte
@@ -72,16 +72,16 @@
 		</Table.Root>
 
 		{#if $message.failed_questions}
-			<div class="flex w-full items-center justify-between">
+			<div class="mt-5 flex w-full items-center">
 				<a
 					href={$message.failed_question_details.split(': ')[1]}
-					class="text-primary inline-flex items-center gap-2 font-medium"
+					class="text-primary w-full font-medium"
 					download="error_report.csv"
 				>
-					<Download size={16} />
-					Download error report
+					<Button class="w-full cursor-pointer py-2 text-base font-semibold"
+						><Download />Download error report</Button
+					>
 				</a>
-				<Button type="submit" class="px-10 py-2 text-base font-semibold">Retry Upload</Button>
 			</div>
 		{:else}
 			<div class="mt-5 w-full font-semibold">

--- a/src/routes/(admin)/questionbank/import/+page.svelte
+++ b/src/routes/(admin)/questionbank/import/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import Label from '$lib/components/ui/label/label.svelte';
-	import X from '@lucide/svelte/icons/x';
+	import * as Table from '$lib/components/ui/table';
+	import CircleCheck from '@lucide/svelte/icons/circle-check';
+	import Download from '@lucide/svelte/icons/download';
 	import Info from '@lucide/svelte/icons/info';
-	import { superForm, fileProxy } from 'sveltekit-superforms';
+	import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
+	import X from '@lucide/svelte/icons/x';
+	import { fileProxy, superForm } from 'sveltekit-superforms';
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import { schema } from './schema.js';
 	import Button from '$lib/components/ui/button/button.svelte';
@@ -22,13 +26,74 @@
 </script>
 
 <Dialog.Root open={$message}>
-	<Dialog.Content class="sm:max-w-[425px]">
+	<Dialog.Content class="text-sm sm:max-w-[512px]">
 		<Dialog.Header>
-			<Dialog.Title>Question Uploading Completed</Dialog.Title>
+			<Dialog.Title class="mb-4 inline-flex items-center gap-2 text-xl font-semibold">
+				{#if $message.failed_questions}
+					<TriangleAlert color="#C7584A" size={28} />
+					File upload error
+				{:else}
+					<CircleCheck color="#1E8F36" size={28} />
+					File upload successful
+				{/if}
+			</Dialog.Title>
 			<Dialog.Description>
-				<div class="text-lg">{$message}</div>
+				{$message.message}
 			</Dialog.Description>
 		</Dialog.Header>
+		<p class="text-muted-foreground mt-2 font-semibold">Upload summary</p>
+		<Table.Root class="rounded-lg bg-blue-50">
+			{#if $message.failed_questions}
+				<Table.Caption class="text-left">
+					Download the error report to fix the row-specific issues and re-upload the file after
+					fixing the errors.
+				</Table.Caption>
+			{/if}
+			<Table.Body>
+				<Table.Row>
+					<Table.Cell class="font-medium">Total Rows</Table.Cell>
+					<Table.Cell>
+						{$message.uploaded_questions}
+					</Table.Cell>
+				</Table.Row>
+				<Table.Row>
+					<Table.Cell class="font-medium">Validated Rows</Table.Cell>
+					<Table.Cell>
+						{$message.success_questions}
+					</Table.Cell>
+				</Table.Row>
+				<Table.Row>
+					<Table.Cell class="font-medium">Errors</Table.Cell>
+					<Table.Cell>
+						{$message.failed_questions}
+					</Table.Cell>
+				</Table.Row>
+			</Table.Body>
+		</Table.Root>
+
+		{#if $message.failed_questions}
+			<div class="flex w-full items-center justify-between">
+				<a
+					href={$message.failed_question_details.split(': ')[1]}
+					class="text-primary inline-flex items-center gap-2 font-medium"
+				>
+					<Download size={16} />
+					Download error report
+				</a>
+				<Button type="submit" class="px-10 py-2 text-base font-semibold">Retry Upload</Button>
+			</div>
+		{:else}
+			<div class="mt-5 w-full font-semibold">
+				<div class="float-end">
+					<Dialog.Close>
+						<Button class="bg-primary-foreground text-primary mr-2">Upload more</Button>
+					</Dialog.Close>
+					<a href="/questionbank" class="bg-primary rounded-md px-5 py-2 text-white"
+						>Go to question bank</a
+					>
+				</div>
+			</div>
+		{/if}
 	</Dialog.Content>
 </Dialog.Root>
 <div class="mx-10 flex flex-col gap-20">


### PR DESCRIPTION
This PR shows different dialogs based on the response of bulk upload
closes: #83 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the question upload completion dialog with clearer success/failure indicators and improved messaging.
  * Added an upload summary table displaying total rows, validated rows, and errors.
  * Provided a download link for error reports and a "Upload more" option when failures occur.
  * Updated dialog actions and layout for a more user-friendly experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->