### PR TITLE
Default Questions Per Page Size to 0

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/Configuration.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/Configuration.svelte
@@ -98,11 +98,11 @@
 		</ConfigureBox>
 		<ConfigureBox title="Question settings" Icon={CircleHelp}>
 			<div class="flex flex-col gap-6">
-				<div class="flex flex-row pt-6">
+				<div class="flex flex-row gap-4 pt-10">
 					<div class="w-1/2">
 						{@render headingSubheading(
-							'Question Pagination',
-							'Set the maximum number of questions per screen'
+							'Questions Per Page',
+							"Enter the number of questions to display per page. Enter '0' to display all questions on a single page"
 						)}
 					</div>
 					<div class=" flex w-1/2 flex-row gap-4">

--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
@@ -15,7 +15,7 @@ export const testSchema = z.object({
 	shuffle: z.boolean().optional().default(false),
 	random_questions: z.boolean().optional().default(false),
 	no_of_random_questions: z.number().nullable().optional(),
-	question_pagination: z.number().optional().default(1),
+	question_pagination: z.number().min(0).optional().default(0),
 	is_template: z.boolean().optional().default(false),
 	template_id: z.string().nullable().optional(),
 	tag_ids: z.array(z.string()).default([]),


### PR DESCRIPTION
The issue closes #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the "Questions Per Page" setting with clearer instructions and improved layout.
  * Users can now set the number of questions per page to zero to display all questions on a single page.

* **Bug Fixes**
  * Ensured that the minimum value for questions per page is zero, preventing negative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->