### PR TITLE
Rename field 'failed_question_details' to 'error_log' as per backend …

### DIFF
--- a/src/routes/(admin)/questionbank/import/+page.svelte
+++ b/src/routes/(admin)/questionbank/import/+page.svelte
@@ -74,7 +74,7 @@
 		{#if $message.failed_questions}
 			<div class="mt-5 flex w-full items-center">
 				<a
-					href={$message.failed_question_details.split(': ')[1]}
+					href={$message.error_log}
 					class="text-primary w-full font-medium"
 					download="error_report.csv"
 				>

--- a/src/routes/(admin)/questionbank/import/+page.svelte
+++ b/src/routes/(admin)/questionbank/import/+page.svelte
@@ -71,7 +71,7 @@
 			</Table.Body>
 		</Table.Root>
 
-		{#if $message.failed_questions}
+		{#if $message.error_log?.startsWith('data:text/csv;base64')}
 			<div class="mt-5 flex w-full items-center">
 				<a
 					href={$message.error_log}


### PR DESCRIPTION
fixes:- #122 

- Renamed field from 'failed_question_details' to 'error_log'
- Removed splitting step since error log is now sent as a base64 string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin > Question Bank > Import: Fixed the error report download so the download link only appears when a valid CSV error log is present and now reliably points to the actual error log. No visual changes; improves accuracy and consistency of error-report downloads for diagnosing import issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->