### PR TITLE
Test Submission Stats for Dashboard

### DIFF
--- a/src/routes/(admin)/dashboard/+page.server.ts
+++ b/src/routes/(admin)/dashboard/+page.server.ts
@@ -1,19 +1,45 @@
 import { BACKEND_URL } from '$env/static/private';
 import { getSessionTokenCookie } from '$lib/server/auth';
-import type { PageServerLoad } from './$types';
+import { fail, superValidate } from 'sveltekit-superforms';
+import type { PageServerLoad, Actions } from './$types';
+import { basedateSchema } from './schema';
+import { zod } from 'sveltekit-superforms/adapters';
+import { redirect } from 'sveltekit-flash-message/server';
 
-export const load: PageServerLoad = async () => {
+
+
+
+export const load: PageServerLoad = async ({ url }) => {
+
 	const token = getSessionTokenCookie();
+	const startDate = url.searchParams.get('start_date');
+	const endDate = url.searchParams.get('end_date');
+
+	const params = new URLSearchParams();
+	if (startDate) params.append('start_date', startDate);
+	if (endDate) params.append('end_date', endDate);
+
 	interface DashboardStats {
 		total_questions: number;
 		total_users: number;
 		total_tests: number;
 	}
-
+	interface TestSummary {
+		total_test_submitted: number;
+		total_test_not_submitted: number;
+		not_submitted_active: number;
+		not_submitted_inactive: number;
+	}
 	const stats: DashboardStats = {
 		total_questions: 0,
 		total_users: 0,
 		total_tests: 0
+	};
+	const summary: TestSummary = {
+		total_test_submitted: 0,
+		total_test_not_submitted: 0,
+		not_submitted_active: 0,
+		not_submitted_inactive: 0,
 	};
 
 	const responseStats = await fetch(`${BACKEND_URL}/organization/aggregated_data`, {
@@ -30,5 +56,65 @@ export const load: PageServerLoad = async () => {
 		stats.total_tests = statsData.total_tests;
 	}
 
-	return { stats };
+	const responseSummary = await fetch(`${BACKEND_URL}/candidate/summary?${params.toString()}`, {
+		method: 'GET',
+		headers: {
+			Authorization: `Bearer ${token}`,
+		},
+	});
+
+	if (responseSummary.ok) {
+		const summaryData = await responseSummary.json();
+		summary.total_test_submitted = summaryData.total_test_submitted;
+		summary.total_test_not_submitted = summaryData.total_test_not_submitted;
+		summary.not_submitted_active = summaryData.not_submitted_active;
+		summary.not_submitted_inactive = summaryData.not_submitted_inactive;
+	}
+
+
+	return { stats, summary }
+
 };
+export const actions: Actions = {
+	applyFilter: async ({ request, cookies }) => {
+		const token = getSessionTokenCookie();
+
+		const form = await superValidate(request, zod(basedateSchema));
+		if (!form.valid) {
+			return fail(400, {
+				form
+			});
+		}
+		const dateData: any = {
+			start_date: form.data.start_date,
+			end_date: form.data.end_date,
+		}
+		const res: Response = await fetch(`${BACKEND_URL}/candidate/summary?start_date=${dateData.start_date}&end_date=${dateData.end_date}`, {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${token}`
+			},
+
+		});
+
+		if (!res.ok) {
+			return fail(401, { form });
+		}
+		let url = '/dashboard';
+		if (dateData.start_date || dateData.end_date) {
+			const params = new URLSearchParams();
+
+			if (dateData.start_date) {
+				params.append("start_date", dateData.start_date);
+			}
+			if (dateData.end_date) {
+				params.append("end_date", dateData.end_date);
+			}
+
+			url += `?${params.toString()}`;
+		}
+
+		throw redirect(303, url, { type: 'success', message: `Filter applied successfully` }, cookies);
+	},
+}

--- a/src/routes/(admin)/dashboard/+page.svelte
+++ b/src/routes/(admin)/dashboard/+page.svelte
@@ -4,6 +4,8 @@
 	import Label from '$lib/components/ui/label/label.svelte';
 	import Info from '@lucide/svelte/icons/info';
 
+	import Applyform from './Applyform.svelte';
+
 	let { data } = $props();
 
 	const information = [
@@ -82,21 +84,17 @@
 </div>
 
 <div>
-	<div class="mt-4 ml-10 flex w-3/4 flex-row justify-between">
+	<div class="mt-4 ml-10 flex w-3/4 flex-row">
 		{#each stats_box as stat}
-			<div class="m-4 w-1/3 rounded-xl bg-white p-4">
-				<p class="font-semibold">{stat.title}</p>
+			<div
+				class="animate-fadeIn m-4 w-1/3 rounded-xl bg-white p-4 shadow-lg hover:scale-105 hover:shadow-2xl hover:shadow-2xl"
+			>
+				<p class="mb-2 border-b pb-2 font-semibold">{stat.title}</p>
 				<p class="text-sm">{stat.description}</p>
-				<div class="p-12 text-5xl">{stat.count}</div>
+				<div class="p-12 text-5xl font-semibold">{stat.count}</div>
 			</div>
 		{/each}
 	</div>
-	<!-- <div class="mt-4 ml-10 flex w-3/4 flex-row justify-between"> -->
-	<!-- 	<div class="m-4 mb-10 h-1/2 w-1/2 rounded-xl bg-white p-4"> -->
-	<!-- 		<div class="h-screen w-full"></div> -->
-	<!-- 	</div> -->
-	<!-- 	<div class="m-4 h-1/2 w-1/2 rounded-xl bg-white p-4"> -->
-	<!-- 		<div class="h-screen w-full"></div> -->
-	<!-- 	</div> -->
-	<!-- </div> -->
+
+	<Applyform {data} />
 </div>

--- a/src/routes/(admin)/dashboard/Applyform.svelte
+++ b/src/routes/(admin)/dashboard/Applyform.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	import * as Form from '$lib/components/ui/form/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import * as Select from '$lib/components/ui/select/index.js';
+	import { type Infer, superForm } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+	import { basedateSchema, type FormSchema } from './schema';
+
+	let { data }: { data: any } = $props();
+	type SummaryItem = { title: string; description: string; count: number };
+
+	let test_summary_box = $state<SummaryItem[]>([]);
+
+	let userData: Partial<Infer<FormSchema>> | null = data?.user || null;
+
+	const form = superForm(userData || data.form, {
+		validators: zodClient(basedateSchema)
+	});
+
+	const { form: formData, enhance } = form;
+
+	$effect(() => {
+		test_summary_box = [
+			{
+				title: ' Tests Submitted',
+				description: 'Number of tests submitted by candidates',
+				count: data?.summary?.total_test_submitted
+			},
+			{
+				title: ' Tests Not Submitted',
+				description: 'Number of tests not submitted by candidates',
+				count: data?.summary?.total_test_not_submitted
+			},
+			{
+				title: ' Active',
+				description: 'Tests not submitted but still active',
+				count: data?.summary?.not_submitted_active
+			},
+			{
+				title: 'Inactive',
+				description: 'Tests not submitted and inactive',
+				count: data?.summary?.not_submitted_inactive
+			}
+		];
+	});
+</script>
+
+<div class="m-4 mt-10 mr-10 ml-10 flex items-center justify-start gap-90">
+	<div class="flex flex-col">
+		<h2 class=" text-2xl font-bold">Test Attempt Details</h2>
+
+		<p class=" text-sm text-gray-600">details of the attempts made by candidates</p>
+	</div>
+
+	<div class="m-4 mt-6 ml-10 flex flex-col items-center">
+		<h3 class="mb-2 text-sm font-semibold text-gray-700">Select Date Range</h3>
+
+		<div>
+			<form method="POST" use:enhance action="?/applyFilter">
+				<div class="flex gap-4">
+					<Form.Field {form} name="start_date">
+						<Form.Control>
+							{#snippet children({ props })}
+								<Form.Label>Start Date</Form.Label>
+								<Input {...props} type="date" bind:value={$formData.start_date} />
+							{/snippet}
+						</Form.Control>
+						<Form.FieldErrors />
+					</Form.Field>
+					<Form.Field {form} name="end_date">
+						<Form.Control>
+							{#snippet children({ props })}
+								<Form.Label>End Date</Form.Label>
+								<Input {...props} type="date" bind:value={$formData.end_date} />
+							{/snippet}
+						</Form.Control>
+						<Form.FieldErrors />
+					</Form.Field>
+				</div>
+
+				<div class="flex items-center justify-center">
+					<Form.Button class="px-4">Apply Filter</Form.Button>
+				</div>
+			</form>
+		</div>
+	</div>
+</div>
+<div class="card m-4 mt-10 ml-10 flex w-full cursor-pointer">
+	{#each test_summary_box as stat}
+		<div
+			class="m-4 w-1/4 rounded-xl bg-white p-4 hover:scale-105 hover:shadow-xl"
+			style="flex: 0 0 20%;"
+		>
+			<div class="flex items-center gap-2 font-semibold">
+				<p class="mb-2 border-b">{stat.title}</p>
+			</div>
+			<p class="text-sm">{stat.description}</p>
+			<div class="p-12 text-5xl">{stat.count}</div>
+		</div>
+	{/each}
+</div>

--- a/src/routes/(admin)/dashboard/Applyform.svelte
+++ b/src/routes/(admin)/dashboard/Applyform.svelte
@@ -45,57 +45,52 @@
 	});
 </script>
 
-<div class="m-4 mt-10 mr-10 ml-10 flex items-center justify-start gap-90">
-	<div class="flex flex-col">
-		<h2 class=" text-2xl font-bold">Test Attempt Details</h2>
-
-		<p class=" text-sm text-gray-600">details of the attempts made by candidates</p>
-	</div>
-
-	<div class="m-4 mt-6 ml-10 flex flex-col items-center">
-		<h3 class="mb-2 text-sm font-semibold text-gray-700">Select Date Range</h3>
-
-		<div>
-			<form method="POST" use:enhance action="?/applyFilter">
-				<div class="flex gap-4">
-					<Form.Field {form} name="start_date">
-						<Form.Control>
-							{#snippet children({ props })}
-								<Form.Label>Start Date</Form.Label>
-								<Input {...props} type="date" bind:value={$formData.start_date} />
-							{/snippet}
-						</Form.Control>
-						<Form.FieldErrors />
-					</Form.Field>
-					<Form.Field {form} name="end_date">
-						<Form.Control>
-							{#snippet children({ props })}
-								<Form.Label>End Date</Form.Label>
-								<Input {...props} type="date" bind:value={$formData.end_date} />
-							{/snippet}
-						</Form.Control>
-						<Form.FieldErrors />
-					</Form.Field>
-				</div>
-
-				<div class="flex items-center justify-center">
-					<Form.Button class="px-4">Apply Filter</Form.Button>
-				</div>
-			</form>
-		</div>
-	</div>
-</div>
-<div class="card m-4 mt-10 ml-10 flex w-full cursor-pointer">
-	{#each test_summary_box as stat}
-		<div
-			class="m-4 w-1/4 rounded-xl bg-white p-4 hover:scale-105 hover:shadow-xl"
-			style="flex: 0 0 20%;"
-		>
-			<div class="flex items-center gap-2 font-semibold">
-				<p class="mb-2 border-b">{stat.title}</p>
+<div class="mt-10 flex w-full justify-center">
+	<div class="w-full max-w-7xl rounded-xl bg-white p-6">
+		<div class="m-4 flex items-start justify-between">
+			<div>
+				<h2 class=" text-2xl font-bold">Test Attempt Details</h2>
+				<p class="text-sm text-gray-600">Details of the Attempts made by Candidates</p>
 			</div>
-			<p class="text-sm">{stat.description}</p>
-			<div class="p-12 text-5xl">{stat.count}</div>
+
+			<div class="mt-4 flex flex-col items-start md:mt-0 md:items-center">
+				<h3 class="mb-2 text-sm font-semibold text-gray-700">Select Date Range</h3>
+				<form method="POST" use:enhance action="?/applyFilter" class="flex flex-col gap-4">
+					<div class="flex flex-col md:flex-row">
+						<Form.Field {form} name="start_date">
+							<Form.Control>
+								{#snippet children({ props })}
+									<Form.Label class="flex items-center justify-center">From</Form.Label>
+									<Input {...props} type="date" bind:value={$formData.start_date} />
+								{/snippet}
+							</Form.Control>
+							<Form.FieldErrors />
+						</Form.Field>
+						<Form.Field {form} name="end_date">
+							<Form.Control>
+								{#snippet children({ props })}
+									<Form.Label class="flex items-center justify-center">To</Form.Label>
+									<Input {...props} type="date" bind:value={$formData.end_date} />
+								{/snippet}
+							</Form.Control>
+							<Form.FieldErrors />
+						</Form.Field>
+					</div>
+
+					<div class="flex justify-center">
+						<Form.Button class="px-4">Apply Filter</Form.Button>
+					</div>
+				</form>
+			</div>
 		</div>
-	{/each}
+
+		<div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+			{#each test_summary_box as stat}
+				<div class="flex flex-col justify-between rounded-lg border p-6 text-center">
+					<p class="text-base font-semibold">{stat.title}</p>
+					<p class="text-4xl">{stat.count}</p>
+				</div>
+			{/each}
+		</div>
+	</div>
 </div>

--- a/src/routes/(admin)/dashboard/schema.ts
+++ b/src/routes/(admin)/dashboard/schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+
+export const basedateSchema = z.object({
+    start_date: z.string().optional(),
+    end_date: z.string().optional()
+
+});
+export type FormSchema = typeof basedateSchema


### PR DESCRIPTION
fixes issue: #109 
This PR adds a backend API to provide test submission statistics for candidates in an organization.

dashboard-

- Returns total tests submitted and total tests not submitted
- For non-submitted tests, includes:
- Count of active test attempts
- Count of inactive test attempts
- Supports filtering by date range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added date-range filter on the Admin Dashboard to refine test attempt data and persist dates in the URL.
  * Introduced a “Test Attempt Details” summary panel showing: Tests Submitted, Tests Not Submitted, Active, and Inactive.
  * Dashboard now returns and displays both overall stats and filtered summaries; Apply Filter provides feedback and updates the view.

* Style
  * Enhanced stat cards with animations, hover effects, and clearer typography.
  * Adjusted dashboard layout for improved spacing and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->