### PR TITLE
display clear error when email already exists

### DIFF
--- a/src/routes/(admin)/users/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/users/[action]/[id]/+page.server.ts
@@ -165,7 +165,7 @@ export const actions: Actions = {
 
 		if (!res.ok) {
 			const err = await res.json();
-			form.errors = { password: [err.detail[0].msg] };
+			form.errors = { email: [err.detail] };
 			return fail(401, { form });
 		}
 


### PR DESCRIPTION
fixes:-118

Fixes the user creation form so that if an email already exists, a clear error message "A user with this email already exists." is displayed under the email field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved validation feedback in the Admin Users form: when a save fails, the error now appears under the email field instead of the password field.
  - Ensures errors are displayed on the correct field, reducing confusion and helping admins quickly address email-related issues (e.g., invalid format or duplicates) during user edits or creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->