### PR TITLE
add district-based filtering for test list

### DIFF
--- a/src/lib/components/DistrictSelection.svelte
+++ b/src/lib/components/DistrictSelection.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import * as Select from '$lib/components/ui/select/index.js';
+	import Badge from '$lib/components/ui/badge/badge.svelte';
+	import { page } from '$app/state';
+
+	const districtList = page.data.districts?.items || [];
+	let { districts = $bindable(), ...rest } = $props();
+
+	const selectedDistricts = $derived(
+		districts?.length
+			? districtList
+					.filter((district: { id: any }) => districts.includes(String(district.id)))
+					.map((district: { name: any }) => district.name)
+			: 'Select districts'
+	);
+</script>
+
+{#snippet myBadge(children: any)}
+	<Badge variant="default" style={'background-color:#3587B4'} class="m-1 rounded-sm  p-2"
+		>{children}</Badge
+	>
+{/snippet}
+
+<Select.Root type="multiple" bind:value={districts} name="districts" {...rest}>
+	<Select.Trigger>
+		{#if districts?.length === 0}
+			{selectedDistricts}
+		{:else}
+			<span class="truncate text-start">
+				{#each selectedDistricts as district}
+					{@render myBadge(district)}
+				{/each}
+			</span>
+		{/if}
+	</Select.Trigger>
+	<Select.Content>
+		<Select.Group>
+			<Select.GroupHeading>Select districts</Select.GroupHeading>
+			{#each districtList as district}
+				<Select.Item value={String(district.id)} label={district.name} />
+			{/each}
+		</Select.Group>
+	</Select.Content>
+</Select.Root>

--- a/src/routes/(admin)/+layout.server.ts
+++ b/src/routes/(admin)/+layout.server.ts
@@ -9,6 +9,7 @@ export const load: PageServerLoad = async () => {
 
 	let states = [];
 	let tags = [];
+	let districts = [];
 
 	const responseState = await fetch(`${BACKEND_URL}/location/state/?skip=0&limit=100`, {
 		method: 'GET',
@@ -36,9 +37,24 @@ export const load: PageServerLoad = async () => {
 		tags = await responseTags.json();
 	}
 
+	const responseDistricts = await fetch(`${BACKEND_URL}/location/district/?skip=0&limit=100`, {
+		method: 'GET',
+		headers: {
+			Authorization: `Bearer ${token}`
+		}
+	});
+
+	if (!responseDistricts.ok) {
+		console.error('Failed to fetch states:', responseDistricts.status, responseDistricts.statusText);
+	} else {
+		districts = await responseDistricts.json();
+	}
+
+
 	return {
 		user: locals.user,
 		states: states,
-		tags: tags
+		tags: tags,
+		districts: districts,
 	};
 };

--- a/src/routes/(admin)/tests/test-[type]/+page.server.ts
+++ b/src/routes/(admin)/tests/test-[type]/+page.server.ts
@@ -20,6 +20,9 @@ export const load: PageServerLoad = async ({ params, url, cookies }) => {
 	const statesList = url.searchParams.getAll('state_ids') || [];
 	const stateParams =
 		statesList.length > 0 ? statesList.map((state) => `state_ids=${state}`).join('&') : '';
+	const districtsList = url.searchParams.getAll('district_ids') || [];
+	const districtParams =
+		districtsList.length > 0 ? districtsList.map((district) => `district_ids=${district}`).join('&') : '';
 
 	// build query string for DataTable pagination/sorting
 	const queryParams = new URLSearchParams({
@@ -32,7 +35,7 @@ export const load: PageServerLoad = async ({ params, url, cookies }) => {
 	});
 
 	// add tag and state params if they exist
-	const queryString = [queryParams.toString(), tagParams, stateParams].filter(Boolean).join('&');
+	const queryString = [queryParams.toString(), tagParams, stateParams, districtParams].filter(Boolean).join('&');
 
 	const token = getSessionTokenCookie();
 	const res = await fetch(`${BACKEND_URL}/test/?${queryString}`, {

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -13,6 +13,7 @@
 	import DeleteDialog from '$lib/components/DeleteDialog.svelte';
 	import { DEFAULT_PAGE_SIZE } from '$lib/constants';
 	import Input from '$lib/components/ui/input/input.svelte';
+	import DistrictSelection from '$lib/components/DistrictSelection.svelte';
 
 	let {
 		data
@@ -41,7 +42,15 @@
 
 	$effect(() => {
 		// check if there are any meaningful search/filter parameters (exclude pagination params)
-		const meaningfulParams = ['search', 'name', 'tag_ids', 'state_ids', 'sortBy', 'sortOrder'];
+		const meaningfulParams = [
+			'search',
+			'name',
+			'tag_ids',
+			'state_ids',
+			'district_ids',
+			'sortBy',
+			'sortOrder'
+		];
 		const hasFilters = meaningfulParams.some((param) => {
 			const value = page.url.searchParams.get(param);
 			return value && value.trim() !== '';
@@ -49,8 +58,10 @@
 
 		const hasTagFilters = page.url.searchParams.getAll('tag_ids').length > 0;
 		const hasStateFilters = page.url.searchParams.getAll('state_ids').length > 0;
+		const hasDistrictFilters = page.url.searchParams.getAll('district_ids').length > 0;
 
-		noTestCreatedYet = totalItems === 0 && !hasFilters && !hasTagFilters && !hasStateFilters;
+		noTestCreatedYet =
+			totalItems === 0 && !hasDistrictFilters && !hasFilters && !hasTagFilters && !hasStateFilters;
 	});
 
 	// handle sorting
@@ -90,6 +101,7 @@
 
 	let filteredTags: string[] = $state([]);
 	let filteredStates: string[] = $state([]);
+	let filteredDistricts: string[] = $state([]);
 	let deleteAction: string | null = $state(null);
 	let searchTimeout: ReturnType<typeof setTimeout>;
 </script>
@@ -199,6 +211,21 @@
 								url.searchParams.delete('state_ids');
 								filteredStates.map((state_id: string) => {
 									url.searchParams.append('state_ids', state_id);
+								});
+								goto(url, { keepFocus: true, invalidateAll: true });
+							}
+						}}
+					/>
+				</div>
+				<div class="w-1/3">
+					<DistrictSelection
+						bind:districts={filteredDistricts}
+						onOpenChange={(e: boolean) => {
+							if (!e) {
+								const url = new URL(page.url);
+								url.searchParams.delete('district_ids');
+								filteredDistricts.map((district_id: string) => {
+									url.searchParams.append('district_ids', district_id);
 								});
 								goto(url, { keepFocus: true, invalidateAll: true });
 							}


### PR DESCRIPTION
fixes: 106

This PR adds district-based filtering in Test Management. Users can select one or more districts to view relevant tests.