### PR TITLE
User Management: Adding states for state admin

### DIFF
--- a/src/routes/(admin)/users/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/users/[action]/[id]/+page.server.ts
@@ -126,6 +126,7 @@ export const actions: Actions = {
 				full_name: form.data.full_name,
 				email: form.data.email,
 				phone: form.data.phone || '',
+				state_ids: form.data.state_ids,
 				organization_id: form.data.organization_id.toString(),
 				role_id: form.data.role_id.toString(),
 				is_active: form.data.is_active ? 'true' : 'false'
@@ -156,6 +157,7 @@ export const actions: Actions = {
 					email: form.data.email,
 					password: form.data.password,
 					phone: form.data.phone || '',
+					state_ids: form.data.state_ids,
 					organization_id: form.data.organization_id.toString(),
 					role_id: form.data.role_id.toString(),
 					is_active: form.data.is_active ? 'true' : 'false'

--- a/src/routes/(admin)/users/[action]/[id]/UserForm.svelte
+++ b/src/routes/(admin)/users/[action]/[id]/UserForm.svelte
@@ -6,6 +6,7 @@
 	import { createUserSchema, editUserSchema, type FormSchema } from './schema';
 	import { type Infer, superForm } from 'sveltekit-superforms';
 	import { zodClient } from 'sveltekit-superforms/adapters';
+	import StateSelection from '$lib/components/StateSelection.svelte';
 
 	let { data }: { data: any } = $props();
 
@@ -14,10 +15,15 @@
 	const schema = isEditMode ? editUserSchema : createUserSchema;
 
 	const form = superForm(userData || data.form, {
-		validators: zodClient(schema)
+		validators: zodClient(schema),
+		dataType: 'json'
 	});
 
 	const { form: formData, enhance } = form;
+
+	if (userData) {
+		$formData.state_ids = userData?.states?.map((state: { id: String }) => String(state.id)) || [];
+	}
 </script>
 
 <form method="POST" use:enhance action="?/save">
@@ -126,6 +132,20 @@
 		</Form.Control>
 		<Form.FieldErrors />
 	</Form.Field>
+	{#if data.roles
+		.find((role) => role.id === $formData.role_id)
+		?.label?.toLowerCase()
+		.includes('state')}
+		<Form.Field {form} name="state_ids">
+			<Form.Control>
+				{#snippet children({ props })}
+					<Form.Label>States</Form.Label>
+					<StateSelection {...props} bind:states={$formData.state_ids} />
+				{/snippet}
+			</Form.Control>
+			<Form.FieldErrors />
+		</Form.Field>
+	{/if}
 	<Form.Field {form} name="is_active">
 		<Form.Control>
 			{#snippet children({ props })}

--- a/src/routes/(admin)/users/[action]/[id]/UserForm.svelte
+++ b/src/routes/(admin)/users/[action]/[id]/UserForm.svelte
@@ -135,7 +135,7 @@
 	{#if data.roles
 		.find((role) => role.id === $formData.role_id)
 		?.label?.toLowerCase()
-		.includes('state')}
+		?.includes('state')}
 		<Form.Field {form} name="state_ids">
 			<Form.Control>
 				{#snippet children({ props })}

--- a/src/routes/(admin)/users/[action]/[id]/schema.ts
+++ b/src/routes/(admin)/users/[action]/[id]/schema.ts
@@ -8,6 +8,7 @@ const baseUserSchema = z.object({
 	phone: z.string().optional(),
 	organization_id: z.number({ message: 'Organization is required' }),
 	role_id: z.number({ message: 'Role is required' }),
+	state_ids: z.array(z.string()).optional(),
 	is_active: z.boolean().optional().default(true)
 });
 


### PR DESCRIPTION
The issue fixes #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assign multiple states to a user during creation and editing when the selected role requires state-level access.
  * A new States selector in the user form lets admins pick multiple states and pre-fills with the user’s current states when editing.
  * Backend/API now accepts and persists the selected states for create and update user operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->