### PR TITLE
Forget pasword

### DIFF
--- a/src/routes/(admin)/questionbank/columns.ts
+++ b/src/routes/(admin)/questionbank/columns.ts
@@ -11,7 +11,7 @@ import { renderComponent } from '$lib/components/ui/data-table/index.js';
 export interface Question {
 	id: string;
 	question_text: string;
-	tags?: Array<{ name: string }>;
+	tags?: Array<{ name: string, tag_type?: { name: string } }>;
 	modified_date: string;
 	options: Array<{ id: string; key: string; value: string }>;
 	correct_answer: string[];
@@ -23,29 +23,32 @@ export const createQuestionColumns = (
 	handleSort: (columnId: string) => void,
 	enableSelection: boolean = false
 ): ColumnDef<Question>[] => [
-	...(enableSelection ? [createSelectionColumn<Question>()] : []),
-	createSortableColumn('question_text', 'Name', currentSortBy, currentSortOrder, handleSort),
-	{
-		id: 'answers',
-		header: 'Answers',
-		cell: ({ row }) => {
-			return renderComponent(Eye, { class: 'text-gray-400' });
+		...(enableSelection ? [createSelectionColumn<Question>()] : []),
+		createSortableColumn('question_text', 'Name', currentSortBy, currentSortOrder, handleSort),
+		{
+			id: 'answers',
+			header: 'Answers',
+			cell: ({ row }) => {
+				return renderComponent(Eye, { class: 'text-gray-400' });
+			},
+			size: 80
 		},
-		size: 80
-	},
-	{
-		accessorKey: 'tags',
-		header: 'Tags',
-		cell: ({ row }) => {
-			const tags = row.original.tags;
-			if (tags && tags.length > 0) {
-				return tags.map((tag) => tag.name).join(', ');
+		{
+			accessorKey: 'tags',
+			header: 'Tags',
+			cell: ({ row }) => {
+				const tags = row.original.tags;
+				if (tags && tags.length > 0) {
+					return tags.map((tag) => {
+						const tagTypeName = tag.tag_type?.name ?? '';
+						return tagTypeName ? `${tag.name} (${tagTypeName})` : tag.name;
+					}).join(', ');
+				}
+				return '';
 			}
-			return '';
-		}
-	},
-	createSortableColumn('modified_date', 'Updated', currentSortBy, currentSortOrder, handleSort, {
-		cell: ({ row }) => formatDate(row.original.modified_date)
-	}),
-	createActionsColumn<Question>('Question', '/questionbank/single-question')
-];
+		},
+		createSortableColumn('modified_date', 'Updated', currentSortBy, currentSortOrder, handleSort, {
+			cell: ({ row }) => formatDate(row.original.modified_date)
+		}),
+		createActionsColumn<Question>('Question', '/questionbank/single-question')
+	];

--- a/src/routes/(admin)/tests/test-[type]/columns.ts
+++ b/src/routes/(admin)/tests/test-[type]/columns.ts
@@ -7,7 +7,7 @@ import { DataTableActions } from '$lib/components/data-table/index.js';
 export interface Test {
 	id: string;
 	name: string;
-	tags?: Array<{ name: string }>;
+	tags?: Array<{ name: string, tag_type?: { name: string } }>;
 	modified_date: string;
 	is_template: boolean;
 	link?: string;
@@ -27,81 +27,85 @@ export const createTestColumns = (
 		canDelete?: boolean;
 	}
 ): ColumnDef<Test>[] => [
-	createSortableColumn('name', 'Name', currentSortBy, currentSortOrder, handleSort),
-	{
-		accessorKey: 'tags',
-		header: 'Tags',
-		cell: ({ row }) => {
-			const tags = row.original.tags;
-			if (tags && tags.length > 0) {
-				return tags.map((tag) => tag.name).join(', ');
-			}
-			return '';
-		}
-	},
-	createSortableColumn('modified_date', 'Updated', currentSortBy, currentSortOrder, handleSort, {
-		cell: ({ row }) => formatDate(row.original.modified_date)
-	}),
-	{
-		id: 'actions',
-		header: '',
-		enableSorting: false,
-		enableHiding: false,
-		cell: ({ row }) => {
-			const test = row.original;
-			const baseUrl = `/tests/test-${isTemplate ? 'template' : 'session'}`;
+		createSortableColumn('name', 'Name', currentSortBy, currentSortOrder, handleSort),
+		{
+			accessorKey: 'tags',
+			header: 'Tags',
+			cell: ({ row }) => {
+				const tags = row.original.tags;
+				if (tags && tags.length > 0) {
+					return tags.map((tag) => {
 
-			// Create custom actions array
-			const customActions = [];
-
-			// Add template-specific actions
-			if (isTemplate) {
-				customActions.push({
-					label: 'Make a Test',
-					href: `/tests/test-session/convert/?template_id=${test.id}`,
-					icon: 'file-plus'
-				});
-			} else {
-				// Add session-specific actions
-				customActions.push({
-					label: 'Clone',
-					href: `${baseUrl}/${test.id}?/clone`,
-					icon: 'copy',
-					method: 'POST'
-				});
-
-				if (test.link) {
-					customActions.push({
-						label: 'Conduct Test',
-						action: () => window.open(`${testTakerUrl}/test/${test.link}`, '_blank'),
-						icon: 'external-link'
-					});
-
-					customActions.push({
-						label: 'Download QR Code',
-						action: async () => {
-							const fileName = `qr-${test.name.replace(/\s+/g, '-').toLowerCase()}`;
-							try {
-								await downloadQRCode(`${testTakerUrl}/test/${test.link}`, fileName);
-							} catch (error) {
-								console.error('Failed to download QR code:', error);
-							}
-						},
-						icon: 'qr-code'
-					});
+						const tagTypeName = tag.tag_type?.name ?? '';
+						return tagTypeName ? `${tag.name} (${tagTypeName})` : tag.name;
+					}).join(', ');
 				}
+				return '';
 			}
+		},
+		createSortableColumn('modified_date', 'Updated', currentSortBy, currentSortOrder, handleSort, {
+			cell: ({ row }) => formatDate(row.original.modified_date)
+		}),
+		{
+			id: 'actions',
+			header: '',
+			enableSorting: false,
+			enableHiding: false,
+			cell: ({ row }) => {
+				const test = row.original;
+				const baseUrl = `/tests/test-${isTemplate ? 'template' : 'session'}`;
 
-			return renderComponent(DataTableActions, {
-				id: test.id,
-				entityName: isTemplate ? 'Test Template' : 'Test Session',
-				editUrl: `${baseUrl}/${test.id}/`,
-				deleteUrl: `${baseUrl}/${test.id}?/delete`,
-				customActions,
-				onDelete: () => onDelete(test.id),
-				canEdit: permissions?.canEdit ?? true,
-				canDelete: permissions?.canDelete ?? true
-			});
+				// Create custom actions array
+				const customActions = [];
+
+				// Add template-specific actions
+				if (isTemplate) {
+					customActions.push({
+						label: 'Make a Test',
+						href: `/tests/test-session/convert/?template_id=${test.id}`,
+						icon: 'file-plus'
+					});
+				} else {
+					// Add session-specific actions
+					customActions.push({
+						label: 'Clone',
+						href: `${baseUrl}/${test.id}?/clone`,
+						icon: 'copy',
+						method: 'POST'
+					});
+
+					if (test.link) {
+						customActions.push({
+							label: 'Conduct Test',
+							action: () => window.open(`${testTakerUrl}/test/${test.link}`, '_blank'),
+							icon: 'external-link'
+						});
+
+						customActions.push({
+							label: 'Download QR Code',
+							action: async () => {
+								const fileName = `qr-${test.name.replace(/\s+/g, '-').toLowerCase()}`;
+								try {
+									await downloadQRCode(`${testTakerUrl}/test/${test.link}`, fileName);
+								} catch (error) {
+									console.error('Failed to download QR code:', error);
+								}
+							},
+							icon: 'qr-code'
+						});
+					}
+				}
+
+				return renderComponent(DataTableActions, {
+					id: test.id,
+					entityName: isTemplate ? 'Test Template' : 'Test Session',
+					editUrl: `${baseUrl}/${test.id}/`,
+					deleteUrl: `${baseUrl}/${test.id}?/delete`,
+					customActions,
+					onDelete: () => onDelete(test.id),
+					canEdit: permissions?.canEdit ?? true,
+					canDelete: permissions?.canDelete ?? true
+				});
+			}
 		}
-	}
-];
+	];

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -2,17 +2,43 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import type { PageData } from './$types.js';
 	import LoginForm from './LoginForm.svelte';
+	import ResetPasswordForm from './ResetPasswordForm.svelte';
 	let { data, event }: { data: PageData; event: Event } = $props();
+
+	let showReset = $state(false);
 </script>
 
 <div class="flex h-screen items-center justify-center">
 	<Card.Root class="w-[350px]">
 		<Card.Header>
-			<Card.Title>Login to Sashakt</Card.Title>
-			<Card.Description>Please enter your email and password to login.</Card.Description>
+			{#if !showReset}
+				<Card.Title>Login to Sashakt</Card.Title>
+				<Card.Description>Please enter your email and password to login.</Card.Description>
+			{:else}
+				<Card.Title>Reset Password</Card.Title>
+				<Card.Description>Please enter your email to send a reset link.</Card.Description>
+			{/if}
 		</Card.Header>
 		<Card.Content>
-			<LoginForm {data} />
+			{#if !showReset}
+				<LoginForm data={{ form: data.loginForm }} />
+				<button
+					type="button"
+					class="mt-2 text-sm text-blue-500 hover:underline focus:outline-none"
+					onclick={() => (showReset = true)}
+				>
+					Forgot Password?
+				</button>
+			{:else}
+				<ResetPasswordForm data={{ form: data.resetForm }} />
+				<button
+					type="button"
+					class="mt-2 text-sm text-blue-500 hover:underline focus:outline-none"
+					onclick={() => (showReset = false)}
+				>
+					Back to Login
+				</button>
+			{/if}
 		</Card.Content>
 	</Card.Root>
 </div>

--- a/src/routes/login/LoginForm.svelte
+++ b/src/routes/login/LoginForm.svelte
@@ -8,13 +8,14 @@
 	let { data }: { data: { form: SuperValidated<Infer<FormSchema>> } } = $props();
 
 	const form = superForm(data.form, {
+		id: 'loginForm',
 		validators: zodClient(loginSchema)
 	});
 
 	const { form: formData, enhance } = form;
 </script>
 
-<form method="POST" use:enhance>
+<form method="POST" action="?/login" use:enhance>
 	<Form.Field {form} name="username">
 		<Form.Control>
 			{#snippet children({ props })}

--- a/src/routes/login/ResetPasswordForm.svelte
+++ b/src/routes/login/ResetPasswordForm.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import * as Form from '$lib/components/ui/form/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { resetSchema, type ResetFormSchema } from './schema';
+	import { type SuperValidated, type Infer, superForm } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+
+	let { data }: { data: { form: SuperValidated<Infer<ResetFormSchema>> } } = $props();
+
+	const form = superForm(data.form, {
+		id: 'resetPasswordForm',
+		validators: zodClient(resetSchema)
+	});
+	const { form: formData, enhance, message } = form;
+</script>
+
+{#if $message}
+	<div class="text-green-600">{$message}</div>
+{/if}
+
+<form method="POST" action="?/reset" use:enhance>
+	<Form.Field {form} name="email">
+		<Form.Control>
+			{#snippet children({ props })}
+				<Form.Label>Email</Form.Label>
+				<Input {...props} bind:value={$formData.email} type="email" />
+			{/snippet}
+		</Form.Control>
+		<Form.FieldErrors />
+	</Form.Field>
+
+	<Form.Button>Send Reset Link</Form.Button>
+</form>

--- a/src/routes/login/schema.ts
+++ b/src/routes/login/schema.ts
@@ -9,3 +9,8 @@ export const loginSchema = z.object({
 });
 
 export type FormSchema = typeof loginSchema;
+
+export const resetSchema = z.object({
+	email: z.string().email('Enter a valid email')
+});
+export type ResetFormSchema = typeof resetSchema;


### PR DESCRIPTION
fixes:-93
Added a forgot-password flow to the admin portal.
Changes Implemented

- Added “Forgot Password” button on the login screen.
- Clicking the button redirects the user to a new “Reset Password” screen.
- User enters their email and clicks “Send reset link”
- Clicking the link opens a page to set and confirm a new password
- Enables  password resets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added password reset flow on the login page with email validation, success messaging, and a toggle between Login and Reset views.
  - Test lists now include a Clone action for sessions and contextual actions to Conduct Test and Download QR Code when available; templates link to Make a Test.

- UI Improvements
  - Tags now display their type in parentheses when available across Question Bank and Tests.
  - Adjusted Answers column width for improved readability.

- Forms
  - Separated login and reset forms with dedicated submission endpoints and enhanced validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->