### PR TITLE
Check Permission for Updating Question Location

### DIFF
--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -50,6 +50,9 @@ export const PERMISSIONS = {
 	DELETE_QUESTION: 'delete_question',
 	READ_QUESTION: 'read_question',
 
+	//Question Location Permission
+	UPDATE_QUESTION_LOCATION: 'update_question_location',
+
 	// Test permissions
 	CREATE_TEST: 'create_test',
 	UPDATE_TEST: 'update_test',
@@ -119,6 +122,9 @@ export const ENTITY_PERMISSIONS = {
 		read: PERMISSIONS.READ_QUESTION,
 		update: PERMISSIONS.UPDATE_QUESTION,
 		delete: PERMISSIONS.DELETE_QUESTION
+	},
+	question_location: {
+		update: PERMISSIONS.UPDATE_QUESTION_LOCATION
 	},
 	test: {
 		create: PERMISSIONS.CREATE_TEST,


### PR DESCRIPTION
Issue fixes #195 - The frontend configuration required for permission check for for updating Question location 

PR https://github.com/sashakt-platform/sashakt-core/pull/275 depends on the current PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new permission that enables authorized users to update question locations in the Question Bank.
  - Updates to state/location selections are now available to users with the appropriate access.

- Bug Fixes
  - Improved and standardized error handling and user feedback for location updates, including clearer flash messages on failures or permission denials.
  - Ensures consistent behavior when updates fail, preserving form context and returning actionable feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->