### PR TITLE
reset pagination to page 1 when filters change

### DIFF
--- a/src/lib/components/Filteration.svelte
+++ b/src/lib/components/Filteration.svelte
@@ -32,6 +32,8 @@
 			if (searchQuery) url.searchParams.set(itemName + '_search', searchQuery.toLowerCase());
 			else url.searchParams.delete(itemName + '_search');
 
+			// reset pagination to first page user searches
+			url.searchParams.set('page', '1');
 			goto(url, { keepFocus: true, invalidateAll: true });
 		}, 300);
 	}

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -199,6 +199,8 @@
 								} else {
 									url.searchParams.delete('search');
 								}
+								// reset pagination to page 1 when search changes
+								url.searchParams.set('page', '1');
 								goto(url, { keepFocus: true, invalidateAll: true });
 							}, 300);
 						}}
@@ -210,7 +212,11 @@
 				</div>
 
 				<div class="w-1/3">
-					<DistrictSelection bind:districts={filteredDistricts} selectedStates={filteredStates} filteration={true} />
+					<DistrictSelection
+						bind:districts={filteredDistricts}
+						selectedStates={filteredStates}
+						filteration={true}
+					/>
 				</div>
 
 				<div class="w-1/3">


### PR DESCRIPTION
Fixes: https://github.com/sashakt-platform/sashakt-portal/issues/191
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination now resets to page 1 whenever searching, adding/removing filters, or applying/closing filter popovers so you see the first page of updated results.
  * Search and filter interactions consistently refresh the items list to avoid empty or stale pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->