### PR TITLE
restrict organization dropdown base on role

### DIFF
--- a/src/routes/(admin)/users/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/users/[action]/[id]/+page.server.ts
@@ -113,6 +113,7 @@ export const load: PageServerLoad = async ({ params }) => {
 		action: params.action,
 		id: params.id,
 		user: userData,
+		currentUser: user,
 		roles: formattedRoles,
 		organizations: formattedOrganizations
 	};
@@ -133,6 +134,17 @@ export const actions: Actions = {
 		// Use appropriate schema based on action
 		const schema = params.action === 'edit' ? editUserSchema : createUserSchema;
 		const form = await superValidate(request, zod(schema));
+
+		// For non-Super Admins, automatically set organization_id to current user's organization
+		const isSuperAdmin =
+			user.permissions?.includes(PERMISSIONS.CREATE_ORGANIZATION) ||
+			user.permissions?.includes(PERMISSIONS.UPDATE_ORGANIZATION) ||
+			user.permissions?.includes(PERMISSIONS.DELETE_ORGANIZATION);
+
+		if (!isSuperAdmin && user.organization_id) {
+			form.data.organization_id = user.organization_id;
+		}
+
 		if (!form.valid) {
 			return fail(400, {
 				form


### PR DESCRIPTION
fixes: https://github.com/sashakt-platform/sashakt-portal/issues/185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Organization field now only visible to Super Admins; non-admin users no longer see or change it.
  - Automatically assigns the user’s organization to new users created by non-super-admins, ensuring consistent data entry.
  - UI now receives the authenticated user, enabling permission-aware behavior.
- Improvements
  - Enhanced permission checks to reliably detect Super Admin capabilities (create, update, delete organization).
  - Streamlined form behavior to reduce errors and simplify workflows for non-admin users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->