### PR TITLE
Default selected Tags for setting Random count

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
@@ -26,7 +26,7 @@
 		questionSelectionMode = 'tagBased';
 	}
 
-	const setDefaultQuestions = () => {
+	const setDefaultTagsRandom = () => {
 		if ($formData.random_tag_count.length === 0 && $formData.tag_ids.length > 0) {
 			$formData.random_tag_count = $formData.tag_ids.map((tag: Filter) => ({
 				id: tag.id,
@@ -75,7 +75,7 @@
 						<RadioGroup.Item
 							id="tagBased"
 							value="tagBased"
-							onclick={() => (($formData.question_revision_ids = []), setDefaultQuestions())}
+							onclick={() => (($formData.question_revision_ids = []), setDefaultTagsRandom())}
 						/>
 						<Label for="tagBased"
 							><p class="font-bold">Random</p>


### PR DESCRIPTION
Fixes #192 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When switching to tag-based random selection, the system now automatically sets a sensible default random count from the chosen tags and clears any prior manual question selections. This ensures test question lists refresh correctly when changing selection modes and prevents stale manual selections from persisting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->