### PR TITLE
fix: profile page crash

### DIFF
--- a/src/routes/(admin)/profile/AccountForm.svelte
+++ b/src/routes/(admin)/profile/AccountForm.svelte
@@ -13,6 +13,7 @@
 
 	const form = superForm(userData || data.form, {
 		validators: zodClient(editUserSchema),
+		dataType: 'json',
 		onResult: ({ result }) => {
 			if (result.type === 'redirect') {
 				isEditMode = false;


### PR DESCRIPTION
fixes:- #170 

Profile page was crashing when a State Admin logged in because the form had nested data (like state info) that normal HTML forms can’t handle.

**Fix:**
Used dataType: 'json' in superForm so it can handle nested data properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated form data handling for the account profile form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->