### PR TITLE
fix: convert empty start/end time to null to avoid datetime validatio…

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/+page.server.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/+page.server.ts
@@ -158,6 +158,8 @@ export const actions: Actions = {
 		}
 		const transformedFormData = {
 			...form.data,
+			start_time: form.data.start_time || null,
+			end_time: form.data.end_time || null,
 			state_ids: form.data.state_ids.map((s) => s.id),
 			tag_ids: form.data.tag_ids.map((t) => t.id),
 			district_ids: form.data.district_ids.map((d) => d.id),


### PR DESCRIPTION
fixes:- #232 
When a user clears the start_time or end_time field in the test form, SvelteKit sends an empty string ("").
The backend expects either a valid datetime or null.
Sending "" caused the following error:

`Input should be a valid datetime or date, input is too short
`

This prevented updating or saving tests when datetime fields were empty.
Updated the save action to convert empty values to null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test submission to properly include start and end time information when available, with appropriate handling for missing values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->