### PR TITLE
Add trailing slash to language API

### DIFF
--- a/src/routes/api/languages/+server.ts
+++ b/src/routes/api/languages/+server.ts
@@ -7,7 +7,7 @@ export const GET: RequestHandler = async () => {
 	const token = getSessionTokenCookie();
 
 	try {
-		const response = await fetch(`${BACKEND_URL}/languages`, {
+		const response = await fetch(`${BACKEND_URL}/languages/`, {
 			method: 'GET',
 			headers: {
 				Authorization: `Bearer ${token}`


### PR DESCRIPTION
It fixes the issue of language Request API unable to fetch language list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the API endpoint URL formatting to ensure proper request routing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->