### PR TITLE
Make tests a default landing page and remove dashboard

### DIFF
--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
-	import ChartColumnIncreasing from '@lucide/svelte/icons/chart-column-increasing';
 	import FileWarning from '@lucide/svelte/icons/file-warning';
 	import ClipboardList from '@lucide/svelte/icons/clipboard-list';
 	import ClipboardCheck from '@lucide/svelte/icons/clipboard-check';
@@ -20,7 +19,6 @@
 
 	// Menu items
 	const menu_items = [
-		{ title: 'Dashboard', url: '/dashboard', icon: ChartColumnIncreasing },
 		{ title: 'Question Bank', url: '/questionbank', icon: FileWarning, entity: 'question' },
 		{
 			title: 'Test Templates',

--- a/src/routes/(admin)/organization/OrganizationForm.svelte
+++ b/src/routes/(admin)/organization/OrganizationForm.svelte
@@ -192,7 +192,7 @@
 		class="sticky right-0 bottom-0 left-0 mt-2 flex w-full border-t-4 bg-white p-3 shadow-md sm:mt-4 sm:p-4"
 	>
 		<div class="flex w-full justify-between gap-2">
-			<a href={resolve('/dashboard')}>
+			<a href={resolve('/tests/test-session')}>
 				<Button variant="outline" class="border-primary text-primary border-1 text-sm sm:text-base"
 					>Cancel</Button
 				>

--- a/src/routes/(admin)/profile/+page.svelte
+++ b/src/routes/(admin)/profile/+page.svelte
@@ -42,7 +42,7 @@
 		{data.currentUser?.full_name ?? 'My Profile'}
 	</h1>
 	<div class="flex gap-2">
-		<a href={resolve('/dashboard')}>
+		<a href={resolve('/tests/test-session')}>
 			<Button variant="outline" class="border-primary text-primary border text-sm sm:text-base"
 				>Cancel</Button
 			>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -5,7 +5,7 @@ export function load() {
 	const user = requireLogin();
 
 	if (user) {
-		redirect(307, '/dashboard');
+		redirect(307, '/tests/test-session');
 	} else {
 		redirect(307, '/login');
 	}

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -57,6 +57,6 @@ export const actions: Actions = {
 		setSessionTokenCookie(cookies, access_token, new Date(Date.now() + accessExpiryMs));
 		setRefreshTokenCookie(cookies, refresh_token);
 
-		throw redirect(303, '/dashboard');
+		throw redirect(303, '/tests/test-session');
 	}
 };

--- a/src/routes/login/page.server.test.ts
+++ b/src/routes/login/page.server.test.ts
@@ -117,9 +117,9 @@ describe('Login Route', () => {
 				} as any);
 				expect.fail('Should have thrown a redirect');
 			} catch (error: any) {
-				// Should redirect to dashboard
+				// Should redirect to tests
 				expect(error.status).toBe(303);
-				expect(error.location).toBe('/dashboard');
+				expect(error.location).toBe('/tests/test-session');
 			}
 
 			// Should set cookies


### PR DESCRIPTION
Fixes https://github.com/sashakt-platform/sashakt-portal/issues/394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the Dashboard option from the sidebar navigation.
  * Updated post-login and authenticated redirects to point to /tests/test-session.
  * Updated “Cancel” links in organization and profile forms to navigate to /tests/test-session.

* **Tests**
  * Updated login test expectations to assert redirects now target /tests/test-session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->