### PR TITLE
Add pause timer setting to test configuration

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/Configuration.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/Configuration.svelte
@@ -355,6 +355,15 @@
 				{/if}
 
 				<div class="flex items-center justify-between">
+					{@render labelTestRules('Pause timer when candidate leaves the test window')}
+					{@render yesNo(
+						$formData.pause_timer_when_inactive,
+						() => ($formData.pause_timer_when_inactive = true),
+						() => ($formData.pause_timer_when_inactive = false)
+					)}
+				</div>
+
+				<div class="flex items-center justify-between">
 					{@render labelTestRules('Shuffle question order per candidate')}
 					<div class="bg-muted flex rounded-xl p-1">
 						<button

--- a/src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts
@@ -81,6 +81,7 @@ const mockValidFormData = {
 	start_time: '',
 	end_time: '',
 	time_limit: null,
+	pause_timer_when_inactive: false,
 	marks_level: 'question',
 	marks: null,
 	marking_scheme: { correct: 1, wrong: 0, skipped: 0 },
@@ -867,6 +868,22 @@ describe('Test Create/Update Page — save action', () => {
 
 			const body = JSON.parse(mockFetch.mock.calls[0][1].body);
 			expect(body.random_tag_count).toEqual([{ tag_id: 'tag1', count: 3 }]);
+		});
+
+		it('passes pause_timer_when_inactive through to the backend payload', async () => {
+			(superValidate as any).mockResolvedValue({
+				valid: true,
+				data: { ...mockValidFormData, pause_timer_when_inactive: true }
+			});
+			mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+			await actions.save({
+				request: mockRequest,
+				params: { type: 'session', id: 'new' },
+				cookies: mockCookies
+			} as any);
+
+			expect(JSON.parse(mockFetch.mock.calls[0][1].body).pause_timer_when_inactive).toBe(true);
 		});
 
 		it('omits section membership fields when updating an existing sectioned test', async () => {

--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
@@ -73,6 +73,7 @@ export const testSchema = z.object({
 	is_active: z.boolean().default(true),
 	start_time: z.string().nullable().optional(),
 	end_time: z.string().nullable().optional(),
+	pause_timer_when_inactive: z.boolean().default(false),
 	time_limit: z.number().nullable().optional(),
 	marks_level: z.enum(Object.values(MarksLevel)).nullable().default(MarksLevel.QUESTION),
 	marks: z.number().nullable().optional(),


### PR DESCRIPTION
## Why
This portal PR adds the admin-facing toggle needed for the paused-timer flow in Sashakt tests.

The broader goal is parity with the existing quiz stack: some tests should be able to pause their timer when the candidate leaves the active test window, while other tests should continue behaving exactly as they do today.

This PR is intentionally small. It only covers the portal slice:
- expose the test-level configuration
- validate it in the form schema
- pass it through unchanged to the backend save payload

## What Changed
- Added `pause_timer_when_inactive` to the test form schema, defaulting to `false`
- Added a yes/no control in the test configuration screen
- Added a server test to verify the field is included in the backend payload

## How To Review
1. Check the schema change in `src/routes/(admin)/tests/test-[type]/[id]/schema.ts`.
2. Check the new toggle in `src/routes/(admin)/tests/test-[type]/[id]/Configuration.svelte`.
3. Check the payload passthrough test in `src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts`.

## File Notes
- `src/routes/(admin)/tests/test-[type]/[id]/schema.ts`
  Adds the new boolean field to the portal form schema with a safe default of `false`.
- `src/routes/(admin)/tests/test-[type]/[id]/Configuration.svelte`
  Adds the admin-facing yes/no control for pausing the timer when the candidate leaves the test window.
- `src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts`
  Verifies that the new field is forwarded to the backend payload when the test is saved.

## Assumptions / Invariants
- Existing tests should continue to behave exactly as before unless this flag is explicitly enabled.
- This flag is expected to be chosen before candidates begin attempts.
- Changing this setting after attempts have started is treated as unsupported for now.
- This PR does not enforce an edit lock in the portal yet; it relies on that product invariant being respected.

## Testing
- `pnpm vitest run "src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts"`

## Related Issue
- Partial for #280 `Configure Session Tracking for Tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Test Rules option to pause the test timer when a candidate leaves the test window; default is off.
* **Tests**
  * Added server-side tests to ensure the new option is present in validated form data and included in save requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-portal/pull/406)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->