### PR TITLE
Swapping Order of Question Type Display During Test Setup

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
@@ -35,6 +35,7 @@
 	}
 
 	const setDefaultTagsRandom = () => {
+		$formData.question_revision_ids = [];
 		if ($formData.random_tag_count.length === 0 && $formData.tag_ids.length > 0) {
 			$formData.random_tag_count = $formData.tag_ids.map((tag: Filter) => ({
 				id: tag.id,
@@ -42,6 +43,7 @@
 			}));
 		}
 	};
+	setDefaultTagsRandom();
 
 	const handleRemoveQuestion = (questionId: number) => {
 		// remove from both IDs and question data
@@ -76,23 +78,22 @@
 			onValueChange={(v) => {
 				if (v === 'manual') $formData.random_tag_count = [];
 				if (v === 'tagBased') {
-					$formData.question_revision_ids = [];
 					setDefaultTagsRandom();
 				}
 			}}
 		>
 			<TabsList class="bg-muted rounded-full p-1">
 				<TabsTrigger
-					value="manual"
-					class="data-[state=active]:bg-background data-[state=active]:text-primary rounded-full px-4 py-1.5 text-sm text-gray-500 data-[state=active]:font-semibold data-[state=active]:shadow"
-				>
-					Manual Selection
-				</TabsTrigger>
-				<TabsTrigger
 					value="tagBased"
 					class="data-[state=active]:bg-background data-[state=active]:text-primary rounded-full px-4 py-1.5 text-sm text-gray-500 data-[state=active]:font-semibold data-[state=active]:shadow"
 				>
 					Auto Selection
+				</TabsTrigger>
+				<TabsTrigger
+					value="manual"
+					class="data-[state=active]:bg-background data-[state=active]:text-primary rounded-full px-4 py-1.5 text-sm text-gray-500 data-[state=active]:font-semibold data-[state=active]:shadow"
+				>
+					Manual Selection
 				</TabsTrigger>
 			</TabsList>
 		</Tabs>

--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
@@ -48,17 +48,7 @@
 				: $formData.random_tag_count.reduce((sum, t) => sum + (Number(t.count ?? 0) || 0), 0)
 	);
 
-	if (
-		!isSectionedTest &&
-		$formData.random_tag_count.length > 0 &&
-		$formData.question_revision_ids.length === 0
-	) {
-		questionSelectionMode = 'tagBased';
-	} else if ($formData.question_revision_ids.length > 0) {
-		questionSelectionMode = 'manual';
-	}
-
-	const setDefaultTagsRandom = () => {
+	const initializeRandomTags = () => {
 		if ($formData.random_tag_count.length === 0 && $formData.tag_ids.length > 0) {
 			$formData.random_tag_count = $formData.tag_ids.map((tag: Filter) => ({
 				id: tag.id,
@@ -66,7 +56,17 @@
 			}));
 		}
 	};
-	setDefaultTagsRandom();
+
+	if (!isSectionedTest) {
+		// If there are explicit question ids, prefer manual mode
+		if ($formData.question_revision_ids.length > 0) {
+			questionSelectionMode = 'manual';
+		} else {
+			// Otherwise initialize/random-tag defaults and use tag-based mode if any tags exist
+			questionSelectionMode = 'tagBased';
+			initializeRandomTags();
+		}
+	}
 
 	const handleRemoveQuestion = (questionId: number) => {
 		$formData.question_revision_ids = $formData.question_revision_ids.filter(
@@ -122,7 +122,7 @@
 					if (v === 'manual') $formData.random_tag_count = [];
 					if (v === 'tagBased') {
 						$formData.question_revision_ids = [];
-						setDefaultTagsRandom();
+						initializeRandomTags();
 					}
 				}}
 			>

--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
@@ -32,10 +32,11 @@
 	// Optional: auto-select mode on load when tags exist
 	if ($formData.random_tag_count.length > 0 && $formData.question_revision_ids.length === 0) {
 		questionSelectionMode = 'tagBased';
+	} else if ($formData.question_revision_ids.length > 0) {
+		questionSelectionMode = 'manual';
 	}
 
 	const setDefaultTagsRandom = () => {
-		$formData.question_revision_ids = [];
 		if ($formData.random_tag_count.length === 0 && $formData.tag_ids.length > 0) {
 			$formData.random_tag_count = $formData.tag_ids.map((tag: Filter) => ({
 				id: tag.id,
@@ -78,6 +79,7 @@
 			onValueChange={(v) => {
 				if (v === 'manual') $formData.random_tag_count = [];
 				if (v === 'tagBased') {
+					$formData.question_revision_ids = [];
 					setDefaultTagsRandom();
 				}
 			}}

--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
@@ -217,4 +217,80 @@ describe('QuestionList', () => {
 			expect(screen.getByText('Auto Selection')).toBeInTheDocument();
 		});
 	});
+
+	describe('auto selection — tags carried over from Primary screen', () => {
+		it('defaults to Auto Selection mode when tags were selected and no explicit question IDs exist', () => {
+			const formData = makeFormData({
+				tag_ids: [{ id: '1', name: 'Science' }],
+				question_revision_ids: [],
+				random_tag_count: []
+			});
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			expect(screen.getByText('Auto Selection')).toBeInTheDocument();
+			expect(screen.queryByText('No questions yet')).not.toBeInTheDocument();
+		});
+
+		it('populates the auto-selection table with tag names from tag_ids', () => {
+			const formData = makeFormData({
+				tag_ids: [
+					{ id: '1', name: 'Science' },
+					{ id: '2', name: 'Maths' }
+				],
+				question_revision_ids: [],
+				random_tag_count: []
+			});
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			expect(screen.getByText('Science')).toBeInTheDocument();
+			expect(screen.getByText('Maths')).toBeInTheDocument();
+		});
+
+		it('shows the "Tags" and "No. of Questions" column headers when tags are present', () => {
+			const formData = makeFormData({
+				tag_ids: [{ id: '3', name: 'History' }],
+				question_revision_ids: [],
+				random_tag_count: []
+			});
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			expect(screen.getByText('Tags')).toBeInTheDocument();
+			expect(screen.getByText('No. of Questions')).toBeInTheDocument();
+		});
+
+		it('shows the auto-selection description text', () => {
+			const formData = makeFormData({
+				tag_ids: [{ id: '1', name: 'Science' }],
+				question_revision_ids: [],
+				random_tag_count: []
+			});
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			expect(
+				screen.getByText(/Select tags and specify how many questions to randomly pull from each/)
+			).toBeInTheDocument();
+		});
+
+		it('uses Manual Selection mode when explicit question IDs exist, even if tags are set', () => {
+			const formData = makeFormData({
+				tag_ids: [{ id: '1', name: 'Science' }],
+				question_revision_ids: [101, 102],
+				question_revisions: [
+					{ id: 101, question_text: 'Q1', tags: [] },
+					{ id: 102, question_text: 'Q2', tags: [] }
+				],
+				random_tag_count: []
+			});
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			// Manual mode shows the question count header, not the auto-selection description
+			expect(screen.queryByText(/Select tags and specify/)).not.toBeInTheDocument();
+			expect(screen.getByText(/2 questions added/)).toBeInTheDocument();
+		});
+	});
 });

--- a/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
@@ -92,7 +92,8 @@ function setupSuperFormMock(overrides: Partial<typeof defaultFormValues> = {}) {
 	return formStore;
 }
 
-function baseData(overrides: Record<string, any> = {}) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function baseData(overrides: Record<string, any> = {}): any {
 	return {
 		form: {},
 		testData: null,
@@ -109,6 +110,10 @@ function baseData(overrides: Record<string, any> = {}) {
 		},
 		user: { id: 1, permissions: [] },
 		test_taker_url: 'http://test-taker.example.com',
+		orgSettings: null,
+		templates: { items: [], total: 0, pages: 0 },
+		templateParams: {},
+		convertTemplate: false,
 		...overrides
 	};
 }
@@ -236,7 +241,7 @@ describe('Test Create/Update Page', () => {
 				name: 'Test Name',
 				description: 'Test Desc',
 				no_of_random_questions: 5,
-				question_revision_ids: [1, 2]
+				question_revision_ids: [1, 2] as any
 			});
 			render(TestCreatePage, { data: baseData() });
 
@@ -248,7 +253,7 @@ describe('Test Create/Update Page', () => {
 				name: 'Test Name',
 				description: 'Test Desc',
 				no_of_random_questions: 2,
-				question_revision_ids: [1, 2]
+				question_revision_ids: [1, 2] as any
 			});
 			render(TestCreatePage, { data: baseData() });
 
@@ -426,6 +431,144 @@ describe('Test Create/Update Page', () => {
 					question_revision_ids: [101]
 				})
 			]);
+		});
+	});
+
+	// ── Full happy-path flow ──────────────────────────────────────────────────
+
+	describe('full happy-path flow — name + tags + manual questions → save', () => {
+		it('saves successfully when name, tags and manual questions are all set', async () => {
+			// Cast to any: tag_ids/question_revision_ids are inferred as never[] in defaultFormValues
+			setupSuperFormMock({
+				name: 'Governance Assessment',
+				description: 'Test description',
+				tag_ids: [{ id: '10', name: 'Science' }] as any,
+				question_revision_ids: [101, 102, 103] as any
+			});
+			render(TestCreatePage, { data: baseData() });
+
+			await fireEvent.click(getBottomNextButton()); // step 1 → step 2
+			await fireEvent.click(getBottomNextButton()); // step 2 → step 3
+			await fireEvent.click(getBottomNextButton()); // Save
+
+			expect(mockSubmit).toHaveBeenCalledOnce();
+		});
+
+		it('form store contains tags and question IDs when Save is triggered', async () => {
+			const formStore = setupSuperFormMock({
+				name: 'Governance Assessment',
+				tag_ids: [
+					{ id: '10', name: 'Science' },
+					{ id: '11', name: 'Maths' }
+				] as any,
+				question_revision_ids: [101, 102] as any
+			});
+			render(TestCreatePage, { data: baseData() });
+
+			await fireEvent.click(getBottomNextButton()); // step 1 → step 2
+			await fireEvent.click(getBottomNextButton()); // step 2 → step 3
+			await fireEvent.click(getBottomNextButton()); // Save
+
+			const stored = get(formStore);
+			expect(stored.tag_ids).toEqual([
+				{ id: '10', name: 'Science' },
+				{ id: '11', name: 'Maths' }
+			]);
+			expect(stored.question_revision_ids).toEqual([101, 102]);
+			expect(mockSubmit).toHaveBeenCalledOnce();
+		});
+
+		it('Next is enabled on step 1 when name and tags are set', () => {
+			setupSuperFormMock({
+				name: 'My Test',
+				tag_ids: [{ id: '5', name: 'History' }] as any
+			});
+			render(TestCreatePage, { data: baseData() });
+
+			expect(getBottomNextButton()).not.toBeDisabled();
+		});
+
+		it('Next is not disabled on step 2 when manual questions are selected', async () => {
+			setupSuperFormMock({
+				name: 'My Test',
+				tag_ids: [{ id: '5', name: 'History' }] as any,
+				question_revision_ids: [201, 202] as any
+			});
+			render(TestCreatePage, { data: baseData() });
+
+			await fireEvent.click(getBottomNextButton()); // step 1 → step 2
+
+			expect(getBottomNextButton()).not.toBeDisabled();
+		});
+	});
+
+	// ── Edit mode — no changes ────────────────────────────────────────────────
+
+	describe('edit mode — existing test with tags and questions, no changes', () => {
+		function makeTestData(overrides: Record<string, any> = {}) {
+			return {
+				id: '42',
+				name: 'Existing Governance Test',
+				description: 'An existing test description',
+				question_revisions: [{ id: 101 }, { id: 102 }, { id: 103 }],
+				question_sets: [],
+				states: [],
+				districts: [],
+				tags: [
+					{ id: '10', name: 'Science' },
+					{ id: '11', name: 'Maths' }
+				],
+				random_tag_counts: [],
+				...overrides
+			};
+		}
+
+		it('can navigate through all steps and save without making any changes', async () => {
+			// populateFormFromTestData will write name/tags/question_ids into the store
+			setupSuperFormMock();
+			render(TestCreatePage, { data: baseData({ testData: makeTestData() }) });
+
+			await fireEvent.click(getBottomNextButton()); // step 1 → step 2
+			await fireEvent.click(getBottomNextButton()); // step 2 → step 3
+			await fireEvent.click(getBottomNextButton()); // Save
+
+			expect(mockSubmit).toHaveBeenCalledOnce();
+		});
+
+		it('initialises superForm with testData (not the blank form)', () => {
+			setupSuperFormMock();
+			const testData = makeTestData();
+			render(TestCreatePage, { data: baseData({ testData }) });
+
+			expect(superForm).toHaveBeenCalledWith(testData, expect.any(Object));
+		});
+
+		it('populates tag_ids and question_revision_ids from testData into the form store', () => {
+			const formStore = setupSuperFormMock();
+			render(TestCreatePage, { data: baseData({ testData: makeTestData() }) });
+
+			const stored = get(formStore);
+			expect(stored.tag_ids).toEqual([
+				{ id: '10', name: 'Science' },
+				{ id: '11', name: 'Maths' }
+			]);
+			expect(stored.question_revision_ids).toEqual([101, 102, 103]);
+		});
+
+		it('Next button is enabled on step 1 because testData has a non-empty name', () => {
+			setupSuperFormMock();
+			render(TestCreatePage, { data: baseData({ testData: makeTestData() }) });
+
+			expect(getBottomNextButton()).not.toBeDisabled();
+		});
+
+		it('Next button is enabled on step 2 because existing questions satisfy the count', async () => {
+			setupSuperFormMock();
+			render(TestCreatePage, { data: baseData({ testData: makeTestData() }) });
+
+			await fireEvent.click(getBottomNextButton()); // step 1 → step 2
+
+			expect(getBottomNextButton()).not.toBeDisabled();
 		});
 	});
 });


### PR DESCRIPTION
Fixes #404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tabs now correctly map to Auto Selection and Manual Selection modes.
  * UI defaults to Manual Selection when existing questions are present.
  * Tag-based counts are initialized immediately so tag-driven options display correct counts without extra interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->