### PR TITLE
Add minimum character length field for subjective questions

### DIFF
--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.server.ts
@@ -139,7 +139,10 @@ export const actions: Actions = {
 
 			if (!response.ok) {
 				const errorMessage = await response.json();
-				const detail = errorMessage.detail || 'Question not Created. Please check all the details.';
+				const detail =
+					errorMessage.detail?.[0]?.msg ||
+					errorMessage.detail ||
+					'Question not Created. Please check all the details.';
 				setFlash({ type: 'error', message: detail }, cookies);
 				return fail(response.status, { form, errorMessage: detail });
 			}
@@ -227,14 +230,10 @@ export const actions: Actions = {
 
 			if (!response.ok) {
 				const errorMessage = await response.json();
-				setFlash(
-					{
-						type: 'error',
-						message: `Failed to update question: ${errorMessage.detail || response.statusText}`
-					},
-					cookies
-				);
-				return fail(500, { form });
+				const detail = errorMessage.detail?.[0]?.msg || errorMessage.detail || response.statusText;
+				const msg = `Failed to update question: ${detail}`;
+				setFlash({ type: 'error', message: msg }, cookies);
+				return fail(response.status, { form });
 			}
 
 			// Transform tag_ids array into the required format

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.server.ts
@@ -233,7 +233,7 @@ export const actions: Actions = {
 				const detail = errorMessage.detail?.[0]?.msg || errorMessage.detail || response.statusText;
 				const msg = `Failed to update question: ${detail}`;
 				setFlash({ type: 'error', message: msg }, cookies);
-				return fail(response.status, { form });
+				return fail(response.status, { form, errorMessage: msg });
 			}
 
 			// Transform tag_ids array into the required format

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
@@ -71,6 +71,7 @@
 
 	const {
 		form: formData,
+		errors,
 		enhance,
 		submit
 	} = superForm(questionData || data.form, {
@@ -861,6 +862,11 @@
 											placeholder="e.g. 200"
 											bind:value={$formData.subjective_answer_min_length}
 										/>
+										{#if $errors.subjective_answer_min_length}
+											<p class="text-destructive text-sm">
+												{$errors.subjective_answer_min_length}
+											</p>
+										{/if}
 									</div>
 									<div class="flex flex-1 flex-col gap-1.5">
 										<Label for="subjective-limit" class="text-sm font-medium">

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+	import Info from '@lucide/svelte/icons/info';
 	import Loader2 from '@lucide/svelte/icons/loader-2';
 	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 	import ListChecks from '@lucide/svelte/icons/list-checks';
@@ -847,30 +848,37 @@
 					</div>
 					<div class="p-6">
 						{#if $formData.question_type === QuestionTypeEnum.Subjective}
-							<div class="flex flex-col gap-2">
-								<div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-gray-50 p-4">
-									<div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-										<Label for="subjective-limit" class="text-sm font-medium sm:w-48">
-											Maximum character limit
+							<div class="rounded-lg border p-4">
+								<div class="flex flex-col gap-4 sm:flex-row">
+									<div class="flex flex-1 flex-col gap-1.5">
+										<Label for="subjective-min-length" class="text-sm font-medium">
+											Minimum Characters
 										</Label>
-										<div class="flex items-center gap-2">
-											<Input
-												id="subjective-limit"
-												type="number"
-												min="1"
-												max="10000"
-												placeholder="e.g., 500"
-												class="w-32"
-												bind:value={$formData.subjective_answer_limit}
-											/>
-											<span class="text-sm text-gray-500">characters</span>
-										</div>
+										<Input
+											id="subjective-min-length"
+											type="number"
+											min="1"
+											placeholder="e.g. 200"
+											bind:value={$formData.subjective_answer_min_length}
+										/>
 									</div>
-									<p class="text-xs text-gray-500">
-										Leave empty for unlimited. Recommended: 200-1000 characters for short answers,
-										1000-5000 for essays.
-									</p>
+									<div class="flex flex-1 flex-col gap-1.5">
+										<Label for="subjective-limit" class="text-sm font-medium">
+											Maximum Characters
+										</Label>
+										<Input
+											id="subjective-limit"
+											type="number"
+											min="1"
+											placeholder="e.g. 1000"
+											bind:value={$formData.subjective_answer_limit}
+										/>
+									</div>
 								</div>
+								<p class="text-muted-foreground mt-3 flex items-center gap-1.5 text-xs">
+									<Info class="size-4 shrink-0" />
+									Recommended characters: 200-1000 for short answers, 1000-5000 for essays.
+								</p>
 							</div>
 						{:else if $formData.question_type === QuestionTypeEnum.SingleChoice || $formData.question_type === QuestionTypeEnum.MultiChoice}
 							<div class="flex flex-col gap-6 overflow-y-scroll scroll-auto">

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
@@ -390,8 +390,8 @@ describe('Single Question Page - Subjective Question Type', () => {
 				data: { ...baseData, questionData: subjectiveQuestionData } as any
 			});
 
-			expect(screen.getByText('Maximum character limit')).toBeInTheDocument();
-			expect(screen.getByText('characters')).toBeInTheDocument();
+			expect(screen.getByText('Minimum Characters')).toBeInTheDocument();
+			expect(screen.getByText('Maximum Characters')).toBeInTheDocument();
 		});
 
 		it('should display prefilled character limit value', () => {
@@ -399,7 +399,7 @@ describe('Single Question Page - Subjective Question Type', () => {
 				data: { ...baseData, questionData: subjectiveQuestionData } as any
 			});
 
-			const limitInput = screen.getByPlaceholderText('e.g., 500');
+			const limitInput = screen.getByPlaceholderText('e.g. 1000');
 			expect(limitInput).toHaveValue(50);
 		});
 
@@ -408,7 +408,9 @@ describe('Single Question Page - Subjective Question Type', () => {
 				data: { ...baseData, questionData: subjectiveQuestionData } as any
 			});
 
-			expect(screen.getByText(/Leave empty for unlimited/i)).toBeInTheDocument();
+			expect(
+				screen.getByText(/Recommended characters: 200-1000 for short answers/i)
+			).toBeInTheDocument();
 		});
 	});
 
@@ -453,7 +455,7 @@ describe('Single Question Page - Subjective Question Type', () => {
 				data: { ...baseData, questionData: subjectiveQuestionData } as any
 			});
 
-			const limitInput = screen.getByPlaceholderText('e.g., 500');
+			const limitInput = screen.getByPlaceholderText('e.g. 1000');
 			await fireEvent.input(limitInput, { target: { value: '1000' } });
 			expect(limitInput).toHaveValue(1000);
 		});
@@ -463,9 +465,46 @@ describe('Single Question Page - Subjective Question Type', () => {
 				data: { ...baseData, questionData: subjectiveQuestionData } as any
 			});
 
-			const limitInput = screen.getByPlaceholderText('e.g., 500');
+			const limitInput = screen.getByPlaceholderText('e.g. 1000');
 			await fireEvent.input(limitInput, { target: { value: '' } });
 			expect(limitInput).toHaveValue(null);
+		});
+
+		it('should allow editing minimum character length', async () => {
+			render(SingleQuestionPage, {
+				data: { ...baseData, questionData: subjectiveQuestionData } as any
+			});
+
+			const minInput = screen.getByPlaceholderText('e.g. 200');
+			await fireEvent.input(minInput, { target: { value: '100' } });
+			expect(minInput).toHaveValue(100);
+		});
+
+		it('should display prefilled minimum character length value', () => {
+			const dataWithMinLength = {
+				...subjectiveQuestionData,
+				subjective_answer_min_length: 150
+			};
+			render(SingleQuestionPage, {
+				data: { ...baseData, questionData: dataWithMinLength } as any
+			});
+
+			const minInput = screen.getByPlaceholderText('e.g. 200');
+			expect(minInput).toHaveValue(150);
+		});
+
+		it('should allow clearing minimum character length', async () => {
+			const dataWithMinLength = {
+				...subjectiveQuestionData,
+				subjective_answer_min_length: 150
+			};
+			render(SingleQuestionPage, {
+				data: { ...baseData, questionData: dataWithMinLength } as any
+			});
+
+			const minInput = screen.getByPlaceholderText('e.g. 200');
+			await fireEvent.input(minInput, { target: { value: '' } });
+			expect(minInput).toHaveValue(null);
 		});
 
 		it('should display prefilled instructions for subjective question', () => {

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/schema.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/schema.ts
@@ -37,6 +37,7 @@ export const questionSchema = z.object({
 		.union([z.array(z.number()), z.number(), z.record(z.string(), z.array(z.number()))])
 		.default([]),
 	subjective_answer_limit: z.coerce.number().int().positive().nullable().optional(),
+	subjective_answer_min_length: z.coerce.number().int().positive().nullable().optional(),
 	is_mandatory: z.boolean().default(false),
 	marking_scheme: marksSchema,
 	solution: z.string().nullable().optional(),

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/schema.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/schema.ts
@@ -47,6 +47,14 @@ export const questionSchema = z.object({
 	block_ids: z.array(z.string()).default([]),
 	tag_ids: z.array(z.object({ id: z.string(), name: z.string() })).default([]),
 	is_active: z.boolean().default(true)
-});
+}).refine(
+	(data) => {
+		const min = data.subjective_answer_min_length;
+		const max = data.subjective_answer_limit;
+		if (min != null && max != null) return min < max;
+		return true;
+	},
+	{ message: 'Minimum characters must be less than maximum characters', path: ['subjective_answer_min_length'] }
+);
 
 export type FormSchema = typeof questionSchema;


### PR DESCRIPTION
fixes :- #419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subjective answers now support a configurable minimum and maximum character range with updated inputs, inline validation, and concise helper info.

* **Bug Fixes**
  * More specific, user-facing error messages for question creation and revision failures; error responses now surface meaningful details and appropriate statuses.

* **Validation**
  * Form validation enforces min < max for subjective answer lengths when both are set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->