### PR TITLE
Filter Tests as All / Mine / Shared

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/+page.server.ts
+++ b/src/routes/(admin)/tests/test-[type]/+page.server.ts
@@ -22,6 +22,7 @@ export const load: PageServerLoad = async ({ params, url, cookies }) => {
 	const search = url.searchParams.get('search') || '';
 	const sortBy = url.searchParams.get('sortBy') || '';
 	const sortOrder = url.searchParams.get('sortOrder') || 'asc';
+	const myTests = url.searchParams.get('my_tests') ?? '';
 
 	const tagIdsList = url.searchParams.getAll('tag_ids') || [];
 	const tagParams =
@@ -50,7 +51,8 @@ export const load: PageServerLoad = async ({ params, url, cookies }) => {
 		size: size.toString(),
 		...(search && { name: search }),
 		...(sortBy && { sort_by: sortBy }),
-		...(sortOrder && { sort_order: sortOrder })
+		...(sortOrder && { sort_order: sortOrder }),
+		...(myTests !== '' && { my_tests: myTests })
 	});
 
 	// add tag and state params if they exist
@@ -86,7 +88,7 @@ export const load: PageServerLoad = async ({ params, url, cookies }) => {
 			questions: [],
 			is_template: is_template,
 			test_taker_url: TEST_TAKER_URL,
-			params: { page, size, search, sortBy, sortOrder }
+			params: { page, size, search, sortBy, sortOrder, myTests }
 		};
 	}
 
@@ -110,6 +112,6 @@ export const load: PageServerLoad = async ({ params, url, cookies }) => {
 		questions,
 		is_template: is_template,
 		test_taker_url: TEST_TAKER_URL,
-		params: { page, size, search, sortBy, sortOrder }
+		params: { page, size, search, sortBy, sortOrder, myTests }
 	};
 };

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -273,7 +273,7 @@
 			</div>
 		</div>
 
-		{#if !data?.is_template && (isStateAdmin(data.user) || hasAssignedDistricts(data.user))}
+		{#if !data?.is_template}
 			<div class="flex items-center gap-2">
 				<span class="text-muted-foreground text-xs">Show:</span>
 				<Tabs value={myTests ?? 'all'} onValueChange={selectMyTestsFilter} class="w-fit">

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -276,7 +276,7 @@
 		<div class="flex items-center gap-2">
 			<span class="text-muted-foreground text-xs">Show:</span>
 			<div class="border-border flex w-fit rounded-md border p-0.5">
-				{#each [{ value: 'all', label: 'All' }, { value: 'true', label: 'Mine' }, { value: 'false', label: 'Shared' }] as option}
+				{#each [{ value: 'all', label: 'All' }, { value: 'true', label: 'Mine' }, { value: 'false', label: 'Shared' }] as option (option.value)}
 					<button
 						type="button"
 						onclick={() => selectMyTestsFilter(option.value as 'all' | 'true' | 'false')}

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -53,14 +53,27 @@
 	const search = $derived(data?.params?.search || '');
 	const sortBy = $derived(data?.params?.sortBy || '');
 	const sortOrder = $derived(data?.params?.sortOrder || 'asc');
+	const myTests = $derived(page.url.searchParams.get('my_tests'));
 
 	const hasActiveFilters = $derived(
 		search ||
 			page.url.searchParams.getAll('tag_ids').length > 0 ||
 			page.url.searchParams.getAll('state_ids').length > 0 ||
 			page.url.searchParams.getAll('tag_type_ids').length > 0 ||
-			page.url.searchParams.getAll('district_ids').length > 0
+			page.url.searchParams.getAll('district_ids').length > 0 ||
+			myTests !== null
 	);
+
+	function selectMyTestsFilter(value: 'all' | 'true' | 'false') {
+		const url = new URL(page.url);
+		if (value === 'all') {
+			url.searchParams.delete('my_tests');
+		} else {
+			url.searchParams.set('my_tests', value);
+		}
+		url.searchParams.set('page', '1');
+		goto(url, { keepFocus: true, invalidateAll: true });
+	}
 	const noTestCreatedYet = $derived(totalItems === 0 && !hasActiveFilters);
 
 	// handle sorting
@@ -255,6 +268,24 @@
 				<div>
 					<TagsSelection bind:tags={filteredTags} filteration={true} tagTypes={filteredTagtypes} />
 				</div>
+			</div>
+		</div>
+
+		<div class="flex items-center gap-2">
+			<span class="text-muted-foreground text-xs">Show:</span>
+			<div class="border-border flex w-fit rounded-md border p-0.5">
+				{#each [{ value: 'all', label: 'All' }, { value: 'true', label: 'Mine' }, { value: 'false', label: 'Shared' }] as option}
+					<button
+						type="button"
+						onclick={() => selectMyTestsFilter(option.value as 'all' | 'true' | 'false')}
+						class="rounded-sm px-2 py-0.5 text-xs font-medium transition-colors
+							{(option.value === 'all' && myTests === null) || myTests === option.value
+							? 'bg-muted text-foreground shadow-sm'
+							: 'text-muted-foreground hover:text-foreground'}"
+					>
+						{option.label}
+					</button>
+				{/each}
 			</div>
 		</div>
 	{/snippet}

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -39,6 +39,7 @@
 			is_template: boolean;
 			tests: any;
 			params: any;
+			user: any;
 		};
 	} = $props();
 
@@ -271,6 +272,7 @@
 			</div>
 		</div>
 
+		{#if !data?.is_template && (isStateAdmin(data.user) || hasAssignedDistricts(data.user))}
 		<div class="flex items-center gap-2">
 			<span class="text-muted-foreground text-xs">Show:</span>
 			<div class="border-border flex w-fit rounded-md border p-0.5">
@@ -288,6 +290,7 @@
 				{/each}
 			</div>
 		</div>
+		{/if}
 	{/snippet}
 
 	{#snippet content()}

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -28,6 +28,7 @@
 		hasAssignedDistricts
 	} from '$lib/utils/permissions.js';
 	import { useTerms } from '$lib/nomenclature';
+	import { Tabs, TabsList, TabsTrigger } from '$lib/components/ui/tabs';
 
 	const term = useTerms();
 
@@ -65,7 +66,7 @@
 			myTests !== null
 	);
 
-	function selectMyTestsFilter(value: 'all' | 'true' | 'false') {
+	function selectMyTestsFilter(value: string) {
 		const url = new URL(page.url);
 		if (value === 'all') {
 			url.searchParams.delete('my_tests');
@@ -273,23 +274,16 @@
 		</div>
 
 		{#if !data?.is_template && (isStateAdmin(data.user) || hasAssignedDistricts(data.user))}
-		<div class="flex items-center gap-2">
-			<span class="text-muted-foreground text-xs">Show:</span>
-			<div class="border-border flex w-fit rounded-md border p-0.5">
-				{#each [{ value: 'all', label: 'All' }, { value: 'true', label: 'Mine' }, { value: 'false', label: 'Shared' }] as option (option.value)}
-					<button
-						type="button"
-						onclick={() => selectMyTestsFilter(option.value as 'all' | 'true' | 'false')}
-						class="rounded-sm px-2 py-0.5 text-xs font-medium transition-colors
-							{(option.value === 'all' && myTests === null) || myTests === option.value
-							? 'bg-muted text-foreground shadow-sm'
-							: 'text-muted-foreground hover:text-foreground'}"
-					>
-						{option.label}
-					</button>
-				{/each}
+			<div class="flex items-center gap-2">
+				<span class="text-muted-foreground text-xs">Show:</span>
+				<Tabs value={myTests ?? 'all'} onValueChange={selectMyTestsFilter} class="w-fit">
+					<TabsList class="h-auto p-0.5">
+						<TabsTrigger value="all" class="px-2 py-0.5 text-xs">All</TabsTrigger>
+						<TabsTrigger value="true" class="px-2 py-0.5 text-xs">Mine</TabsTrigger>
+						<TabsTrigger value="false" class="px-2 py-0.5 text-xs">Shared</TabsTrigger>
+					</TabsList>
+				</Tabs>
 			</div>
-		</div>
 		{/if}
 	{/snippet}
 

--- a/src/routes/(admin)/tests/test-[type]/page.server.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/page.server.test.ts
@@ -222,6 +222,42 @@ describe('Test Management Listing — load()', () => {
 			expect(callUrl).toContain('tag_type_ids=6');
 		});
 
+		it('should forward my_tests=true when set', async () => {
+			mockSuccessfulFetch();
+			await load({
+				params: { type: 'session' },
+				url: makeUrl('/tests/test-session', 'my_tests=true'),
+				cookies: mockCookies
+			} as any);
+
+			const callUrl: string = mockFetch.mock.calls[0][0];
+			expect(callUrl).toContain('my_tests=true');
+		});
+
+		it('should forward my_tests=false when set', async () => {
+			mockSuccessfulFetch();
+			await load({
+				params: { type: 'session' },
+				url: makeUrl('/tests/test-session', 'my_tests=false'),
+				cookies: mockCookies
+			} as any);
+
+			const callUrl: string = mockFetch.mock.calls[0][0];
+			expect(callUrl).toContain('my_tests=false');
+		});
+
+		it('should omit my_tests from API call when not in URL', async () => {
+			mockSuccessfulFetch();
+			await load({
+				params: { type: 'session' },
+				url: makeUrl('/tests/test-session'),
+				cookies: mockCookies
+			} as any);
+
+			const callUrl: string = mockFetch.mock.calls[0][0];
+			expect(callUrl).not.toContain('my_tests');
+		});
+
 		it('should send Bearer token in Authorization header', async () => {
 			mockSuccessfulFetch();
 			await load({
@@ -307,8 +343,20 @@ describe('Test Management Listing — load()', () => {
 				size: 10,
 				search: 'quiz',
 				sortBy: 'name',
-				sortOrder: 'desc'
+				sortOrder: 'desc',
+				myTests: ''
 			});
+		});
+
+		it('should return myTests in params when my_tests is set', async () => {
+			mockSuccessfulFetch();
+			const result = (await load({
+				params: { type: 'session' },
+				url: makeUrl('/tests/test-session', 'my_tests=true'),
+				cookies: mockCookies
+			} as any)) as any;
+
+			expect(result.params.myTests).toBe('true');
 		});
 	});
 

--- a/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
@@ -420,11 +420,11 @@ describe('Test Management Listing Page', () => {
 			expect(screen.queryByRole('tab', { name: 'Mine' })).not.toBeInTheDocument();
 		});
 
-		it('does not render the segmented control when user is not scoped to any location', () => {
+		it('also renders the segmented control when user is not scoped to any location', () => {
 			vi.mocked(isStateAdmin).mockReturnValue(false);
 			vi.mocked(hasAssignedDistricts).mockReturnValue(false);
 			render(TestListingPage, { data: withItems() });
-			expect(screen.queryByText('Show:')).not.toBeInTheDocument();
+			expect(screen.queryByText('Show:')).toBeInTheDocument();
 		});
 
 		it('renders the segmented control when user is a state admin', () => {

--- a/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
@@ -395,19 +395,50 @@ describe('Test Management Listing Page', () => {
 
 		beforeEach(() => {
 			(page as any).url = new URL('http://localhost/tests/test-session');
+			vi.mocked(isStateAdmin).mockReturnValue(true);
 		});
 
 		// ── Rendering ────────────────────────────────────────────────────────
-		it('renders the "Show:" label', () => {
+		it('renders the "Show:" label for session mode', () => {
 			render(TestListingPage, { data: withItems() });
 			expect(screen.getByText('Show:')).toBeInTheDocument();
 		});
 
-		it('renders all three filter buttons', () => {
+		it('renders all three filter buttons for session mode', () => {
 			render(TestListingPage, { data: withItems() });
 			expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
 			expect(screen.getByRole('button', { name: 'Mine' })).toBeInTheDocument();
 			expect(screen.getByRole('button', { name: 'Shared' })).toBeInTheDocument();
+		});
+
+		it('does not render the segmented control for template mode', () => {
+			vi.mocked(isStateAdmin).mockReturnValue(true);
+			render(TestListingPage, {
+				data: baseData(true, [{ id: '1', name: 'Template A' }])
+			});
+			expect(screen.queryByText('Show:')).not.toBeInTheDocument();
+			expect(screen.queryByRole('button', { name: 'Mine' })).not.toBeInTheDocument();
+		});
+
+		it('does not render the segmented control when user is not scoped to any location', () => {
+			vi.mocked(isStateAdmin).mockReturnValue(false);
+			vi.mocked(hasAssignedDistricts).mockReturnValue(false);
+			render(TestListingPage, { data: withItems() });
+			expect(screen.queryByText('Show:')).not.toBeInTheDocument();
+		});
+
+		it('renders the segmented control when user is a state admin', () => {
+			vi.mocked(isStateAdmin).mockReturnValue(true);
+			vi.mocked(hasAssignedDistricts).mockReturnValue(false);
+			render(TestListingPage, { data: withItems() });
+			expect(screen.getByText('Show:')).toBeInTheDocument();
+		});
+
+		it('renders the segmented control when user has assigned districts', () => {
+			vi.mocked(isStateAdmin).mockReturnValue(false);
+			vi.mocked(hasAssignedDistricts).mockReturnValue(true);
+			render(TestListingPage, { data: withItems() });
+			expect(screen.getByText('Show:')).toBeInTheDocument();
 		});
 
 		// ── Active state ─────────────────────────────────────────────────────

--- a/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
@@ -406,9 +406,9 @@ describe('Test Management Listing Page', () => {
 
 		it('renders all three filter buttons for session mode', () => {
 			render(TestListingPage, { data: withItems() });
-			expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
-			expect(screen.getByRole('button', { name: 'Mine' })).toBeInTheDocument();
-			expect(screen.getByRole('button', { name: 'Shared' })).toBeInTheDocument();
+			expect(screen.getByRole('tab', { name: 'All' })).toBeInTheDocument();
+			expect(screen.getByRole('tab', { name: 'Mine' })).toBeInTheDocument();
+			expect(screen.getByRole('tab', { name: 'Shared' })).toBeInTheDocument();
 		});
 
 		it('does not render the segmented control for template mode', () => {
@@ -417,7 +417,7 @@ describe('Test Management Listing Page', () => {
 				data: baseData(true, [{ id: '1', name: 'Template A' }])
 			});
 			expect(screen.queryByText('Show:')).not.toBeInTheDocument();
-			expect(screen.queryByRole('button', { name: 'Mine' })).not.toBeInTheDocument();
+			expect(screen.queryByRole('tab', { name: 'Mine' })).not.toBeInTheDocument();
 		});
 
 		it('does not render the segmented control when user is not scoped to any location', () => {
@@ -444,43 +444,43 @@ describe('Test Management Listing Page', () => {
 		// ── Active state ─────────────────────────────────────────────────────
 		it('"All" button is active when no my_tests param is set', () => {
 			render(TestListingPage, { data: withItems() });
-			expect(screen.getByRole('button', { name: 'All' })).toHaveClass('bg-muted');
+			expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('data-state', 'active');
 		});
 
 		it('"Mine" button is active when my_tests=true', () => {
 			(page as any).url = new URL('http://localhost/tests/test-session?my_tests=true');
 			render(TestListingPage, { data: withItems() });
-			expect(screen.getByRole('button', { name: 'Mine' })).toHaveClass('bg-muted');
+			expect(screen.getByRole('tab', { name: 'Mine' })).toHaveAttribute('data-state', 'active');
 		});
 
 		it('"Shared" button is active when my_tests=false', () => {
 			(page as any).url = new URL('http://localhost/tests/test-session?my_tests=false');
 			render(TestListingPage, { data: withItems() });
-			expect(screen.getByRole('button', { name: 'Shared' })).toHaveClass('bg-muted');
+			expect(screen.getByRole('tab', { name: 'Shared' })).toHaveAttribute('data-state', 'active');
 		});
 
 		it('"All" button is not active when my_tests=true', () => {
 			(page as any).url = new URL('http://localhost/tests/test-session?my_tests=true');
 			render(TestListingPage, { data: withItems() });
-			expect(screen.getByRole('button', { name: 'All' })).not.toHaveClass('bg-muted');
+			expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('data-state', 'inactive');
 		});
 
 		it('"Mine" button is not active when no my_tests param is set', () => {
 			render(TestListingPage, { data: withItems() });
-			expect(screen.getByRole('button', { name: 'Mine' })).not.toHaveClass('bg-muted');
+			expect(screen.getByRole('tab', { name: 'Mine' })).toHaveAttribute('data-state', 'inactive');
 		});
 
 		// ── Click navigation ─────────────────────────────────────────────────
 		it('clicking "Mine" sets my_tests=true in the URL', async () => {
 			render(TestListingPage, { data: withItems() });
-			await fireEvent.click(screen.getByRole('button', { name: 'Mine' }));
+			await fireEvent.click(screen.getByRole('tab', { name: 'Mine' }));
 			const [calledUrl] = vi.mocked(goto).mock.calls[0] as [URL, unknown];
 			expect(calledUrl.searchParams.get('my_tests')).toBe('true');
 		});
 
 		it('clicking "Shared" sets my_tests=false in the URL', async () => {
 			render(TestListingPage, { data: withItems() });
-			await fireEvent.click(screen.getByRole('button', { name: 'Shared' }));
+			await fireEvent.click(screen.getByRole('tab', { name: 'Shared' }));
 			const [calledUrl] = vi.mocked(goto).mock.calls[0] as [URL, unknown];
 			expect(calledUrl.searchParams.get('my_tests')).toBe('false');
 		});
@@ -488,21 +488,21 @@ describe('Test Management Listing Page', () => {
 		it('clicking "All" removes my_tests from the URL', async () => {
 			(page as any).url = new URL('http://localhost/tests/test-session?my_tests=true');
 			render(TestListingPage, { data: withItems() });
-			await fireEvent.click(screen.getByRole('button', { name: 'All' }));
+			await fireEvent.click(screen.getByRole('tab', { name: 'All' }));
 			const [calledUrl] = vi.mocked(goto).mock.calls[0] as [URL, unknown];
 			expect(calledUrl.searchParams.has('my_tests')).toBe(false);
 		});
 
 		it('resets page to 1 when a filter option is clicked', async () => {
 			render(TestListingPage, { data: withItems() });
-			await fireEvent.click(screen.getByRole('button', { name: 'Mine' }));
+			await fireEvent.click(screen.getByRole('tab', { name: 'Mine' }));
 			const [calledUrl] = vi.mocked(goto).mock.calls[0] as [URL, unknown];
 			expect(calledUrl.searchParams.get('page')).toBe('1');
 		});
 
 		it('calls goto with keepFocus: true and invalidateAll: true', async () => {
 			render(TestListingPage, { data: withItems() });
-			await fireEvent.click(screen.getByRole('button', { name: 'Mine' }));
+			await fireEvent.click(screen.getByRole('tab', { name: 'Mine' }));
 			expect(goto).toHaveBeenCalledWith(expect.any(URL), {
 				keepFocus: true,
 				invalidateAll: true

--- a/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
@@ -388,4 +388,94 @@ describe('Test Management Listing Page', () => {
 			});
 		});
 	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	describe('my_tests segmented control', () => {
+		const withItems = () => baseData(false, [{ id: '1', name: 'Test A' }]);
+
+		beforeEach(() => {
+			(page as any).url = new URL('http://localhost/tests/test-session');
+		});
+
+		// ── Rendering ────────────────────────────────────────────────────────
+		it('renders the "Show:" label', () => {
+			render(TestListingPage, { data: withItems() });
+			expect(screen.getByText('Show:')).toBeInTheDocument();
+		});
+
+		it('renders all three filter buttons', () => {
+			render(TestListingPage, { data: withItems() });
+			expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: 'Mine' })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: 'Shared' })).toBeInTheDocument();
+		});
+
+		// ── Active state ─────────────────────────────────────────────────────
+		it('"All" button is active when no my_tests param is set', () => {
+			render(TestListingPage, { data: withItems() });
+			expect(screen.getByRole('button', { name: 'All' })).toHaveClass('bg-muted');
+		});
+
+		it('"Mine" button is active when my_tests=true', () => {
+			(page as any).url = new URL('http://localhost/tests/test-session?my_tests=true');
+			render(TestListingPage, { data: withItems() });
+			expect(screen.getByRole('button', { name: 'Mine' })).toHaveClass('bg-muted');
+		});
+
+		it('"Shared" button is active when my_tests=false', () => {
+			(page as any).url = new URL('http://localhost/tests/test-session?my_tests=false');
+			render(TestListingPage, { data: withItems() });
+			expect(screen.getByRole('button', { name: 'Shared' })).toHaveClass('bg-muted');
+		});
+
+		it('"All" button is not active when my_tests=true', () => {
+			(page as any).url = new URL('http://localhost/tests/test-session?my_tests=true');
+			render(TestListingPage, { data: withItems() });
+			expect(screen.getByRole('button', { name: 'All' })).not.toHaveClass('bg-muted');
+		});
+
+		it('"Mine" button is not active when no my_tests param is set', () => {
+			render(TestListingPage, { data: withItems() });
+			expect(screen.getByRole('button', { name: 'Mine' })).not.toHaveClass('bg-muted');
+		});
+
+		// ── Click navigation ─────────────────────────────────────────────────
+		it('clicking "Mine" sets my_tests=true in the URL', async () => {
+			render(TestListingPage, { data: withItems() });
+			await fireEvent.click(screen.getByRole('button', { name: 'Mine' }));
+			const [calledUrl] = vi.mocked(goto).mock.calls[0] as [URL, unknown];
+			expect(calledUrl.searchParams.get('my_tests')).toBe('true');
+		});
+
+		it('clicking "Shared" sets my_tests=false in the URL', async () => {
+			render(TestListingPage, { data: withItems() });
+			await fireEvent.click(screen.getByRole('button', { name: 'Shared' }));
+			const [calledUrl] = vi.mocked(goto).mock.calls[0] as [URL, unknown];
+			expect(calledUrl.searchParams.get('my_tests')).toBe('false');
+		});
+
+		it('clicking "All" removes my_tests from the URL', async () => {
+			(page as any).url = new URL('http://localhost/tests/test-session?my_tests=true');
+			render(TestListingPage, { data: withItems() });
+			await fireEvent.click(screen.getByRole('button', { name: 'All' }));
+			const [calledUrl] = vi.mocked(goto).mock.calls[0] as [URL, unknown];
+			expect(calledUrl.searchParams.has('my_tests')).toBe(false);
+		});
+
+		it('resets page to 1 when a filter option is clicked', async () => {
+			render(TestListingPage, { data: withItems() });
+			await fireEvent.click(screen.getByRole('button', { name: 'Mine' }));
+			const [calledUrl] = vi.mocked(goto).mock.calls[0] as [URL, unknown];
+			expect(calledUrl.searchParams.get('page')).toBe('1');
+		});
+
+		it('calls goto with keepFocus: true and invalidateAll: true', async () => {
+			render(TestListingPage, { data: withItems() });
+			await fireEvent.click(screen.getByRole('button', { name: 'Mine' }));
+			expect(goto).toHaveBeenCalledWith(expect.any(URL), {
+				keepFocus: true,
+				invalidateAll: true
+			});
+		});
+	});
 });


### PR DESCRIPTION
Fixes #423 

Depends on Backend PR -https://github.com/sashakt-platform/sashakt-core/pull/481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Show:" segmented filter in test listings (All / Mine / Shared) for admins and users with assigned districts; changing it resets pagination and updates the URL parameter.

* **Bug Fixes / Behavior**
  * Filter selection is forwarded to backend requests when set; omitted when not present.

* **Tests**
  * Expanded tests for rendering, URL param behavior, navigation, and active-state logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->