### PR TITLE
Prevent invalid mandatory question set limits

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/+page.server.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad, Actions } from './$types.js';
-import { testSchema } from './schema';
+import { getQuestionSetMandatoryLimitError, testSchema } from './schema';
 import { superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 import { getSessionTokenCookie, requireLogin } from '$lib/server/auth.js';
@@ -250,6 +250,23 @@ export const actions: Actions = {
 				{
 					type: 'error',
 					message: `${term(subjectKey)} not created. Please check all the details.`
+				},
+				cookies
+			);
+			return fail(400, { form });
+		}
+		const questionSetMandatoryLimitError = getQuestionSetMandatoryLimitError(
+			form.data.question_sets
+		);
+		if (questionSetMandatoryLimitError) {
+			form.errors = {
+				...form.errors,
+				_errors: [questionSetMandatoryLimitError]
+			};
+			setFlash(
+				{
+					type: 'error',
+					message: questionSetMandatoryLimitError
 				},
 				cookies
 			);

--- a/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
@@ -8,7 +8,7 @@
 
 	import { superForm, type Infer, type SuperValidated } from 'sveltekit-superforms';
 	import { zod4Client } from 'sveltekit-superforms/adapters';
-	import { testSchema, type FormSchema } from './schema';
+	import { getQuestionSetMandatoryLimitError, testSchema, type FormSchema } from './schema';
 	import type { Filter } from '$lib/types/filters';
 	import { goto } from '$app/navigation';
 	import {
@@ -70,6 +70,9 @@
 	});
 
 	const isSectionedTest = $derived(($formData.question_sets?.length ?? 0) > 0);
+	const questionSetMandatoryLimitError = $derived(
+		getQuestionSetMandatoryLimitError($formData.question_sets)
+	);
 	const totalQuestionCount = $derived(
 		isSectionedTest
 			? ($formData.question_sets || []).reduce(
@@ -179,7 +182,8 @@
 			(currentScreen === typeOfScreen.configuration &&
 				$formData.random_questions &&
 				($formData.no_of_random_questions ?? 0) <= 0) ||
-			($formData.no_of_random_questions ?? 0) > totalQuestionCount
+			($formData.no_of_random_questions ?? 0) > totalQuestionCount ||
+			(currentScreen === typeOfScreen.configuration && Boolean(questionSetMandatoryLimitError))
 	);
 
 	function handlePrevious() {
@@ -304,6 +308,13 @@
 			</div>
 		</div>
 	{:else if currentScreen === typeOfScreen.configuration}
+		{#if questionSetMandatoryLimitError}
+			<div
+				class="mx-4 mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 sm:mx-8 md:mx-10"
+			>
+				{questionSetMandatoryLimitError}
+			</div>
+		{/if}
 		<Configuration {formData} orgSettings={data.orgSettings} />
 	{/if}
 

--- a/src/routes/(admin)/tests/test-[type]/[id]/SectionedQuestionSets.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/SectionedQuestionSets.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Infer } from 'sveltekit-superforms';
-	import type { FormSchema } from './schema';
+	import { getMandatoryQuestionCount, type FormSchema } from './schema';
 	import RichText from '$lib/components/RichText.svelte';
 
 	type QuestionSet = Infer<FormSchema>['question_sets'][number];
@@ -63,6 +63,11 @@
 				</div>
 				<div class="text-muted-foreground text-sm">
 					Attempt limit: {questionSet.max_questions_allowed_to_attempt}
+					{#if getMandatoryQuestionCount(questionSet) > questionSet.max_questions_allowed_to_attempt}
+						<p class="mt-1 text-xs text-red-600">
+							{getMandatoryQuestionCount(questionSet)} mandatory question(s) exceed this attempt limit.
+						</p>
+					{/if}
 				</div>
 			</div>
 

--- a/src/routes/(admin)/tests/test-[type]/[id]/SectionedQuestionSets.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/SectionedQuestionSets.svelte.test.ts
@@ -23,11 +23,47 @@ describe('SectionedQuestionSets', () => {
 			]
 		});
 
-		expect(screen.getByText("Section membership can't be edited in portal yet.")).toBeInTheDocument();
+		expect(
+			screen.getByText("Section membership can't be edited in portal yet.")
+		).toBeInTheDocument();
 		expect(screen.getByText('Physics')).toBeInTheDocument();
 		expect(screen.getByText('Mechanics section')).toBeInTheDocument();
 		expect(screen.getByText('Attempt limit: 2')).toBeInTheDocument();
 		expect(screen.getByText(/What is velocity\?/)).toBeInTheDocument();
 		expect(screen.getByText('Tags: Motion')).toBeInTheDocument();
+	});
+
+	it('warns when mandatory questions exceed the attempt limit', () => {
+		render(SectionedQuestionSets, {
+			questionSets: [
+				{
+					id: 10,
+					title: 'Physics',
+					description: 'Mechanics section',
+					display_order: 1,
+					max_questions_allowed_to_attempt: 1,
+					marking_scheme: { correct: 4, wrong: -1, skipped: 0 },
+					question_revision_ids: [101, 102],
+					question_revisions: [
+						{
+							id: 101,
+							question_text: 'What is velocity?',
+							is_mandatory: true,
+							tags: []
+						},
+						{
+							id: 102,
+							question_text: 'What is force?',
+							is_mandatory: true,
+							tags: []
+						}
+					]
+				}
+			]
+		});
+
+		expect(
+			screen.getByText('2 mandatory question(s) exceed this attempt limit.')
+		).toBeInTheDocument();
 	});
 });

--- a/src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts
@@ -653,6 +653,48 @@ describe('Test Create/Update Page — save action', () => {
 
 			expect(mockFetch).not.toHaveBeenCalled();
 		});
+
+		it('blocks sectioned tests when mandatory questions exceed the attempt limit', async () => {
+			const form = {
+				valid: true,
+				errors: {},
+				data: {
+					...mockValidFormData,
+					question_sets: [
+						{
+							id: 10,
+							title: 'Physics',
+							description: 'Section A',
+							display_order: 1,
+							max_questions_allowed_to_attempt: 1,
+							marking_scheme: { correct: 4, wrong: -1, skipped: 0 },
+							question_revision_ids: [1, 2],
+							question_revisions: [
+								{ id: 1, question_text: 'What is velocity?', is_mandatory: true, tags: [] },
+								{ id: 2, question_text: 'What is force?', is_mandatory: true, tags: [] }
+							]
+						}
+					]
+				}
+			};
+			(superValidate as any).mockResolvedValue(form);
+
+			const result = await actions.save({
+				request: mockRequest,
+				params: { type: 'session', id: 'new' },
+				cookies: mockCookies
+			} as any);
+
+			const expectedMessage =
+				"Question set 'Physics' has 2 mandatory question(s), but only 1 question(s) can be attempted.";
+			expect(result).toEqual({ status: 400, data: { form } });
+			expect(form.errors).toEqual({ _errors: [expectedMessage] });
+			expect(setFlash).toHaveBeenCalledWith(
+				{ type: 'error', message: expectedMessage },
+				mockCookies
+			);
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
 	});
 
 	// ── Create (id=new) ──────────────────────────────────────────────────────

--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
@@ -16,6 +16,7 @@ const questionPreviewSchema = z
 	.object({
 		id: z.number(),
 		question_text: z.string().default(''),
+		is_mandatory: z.boolean().default(false),
 		tags: z.array(z.object({ name: z.string() })).default([])
 	})
 	.passthrough();
@@ -31,7 +32,40 @@ export const questionSetSchema = z
 		question_revision_ids: z.array(z.number()).default([]),
 		question_revisions: z.array(questionPreviewSchema).default([])
 	})
-	.passthrough();
+	.passthrough()
+	.superRefine((questionSet, ctx) => {
+		const mandatoryQuestionCount = getMandatoryQuestionCount(questionSet);
+		if (mandatoryQuestionCount > questionSet.max_questions_allowed_to_attempt) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['max_questions_allowed_to_attempt'],
+				message: `Question set '${questionSet.title}' has ${mandatoryQuestionCount} mandatory question(s), but only ${questionSet.max_questions_allowed_to_attempt} question(s) can be attempted.`
+			});
+		}
+	});
+
+type QuestionSetForMandatoryLimit = {
+	title: string;
+	max_questions_allowed_to_attempt: number;
+	question_revisions?: Array<{ is_mandatory?: boolean }>;
+};
+
+export function getMandatoryQuestionCount(questionSet: QuestionSetForMandatoryLimit) {
+	return (questionSet.question_revisions ?? []).filter((question) => question.is_mandatory).length;
+}
+
+export function getQuestionSetMandatoryLimitError(
+	questionSets: QuestionSetForMandatoryLimit[] = []
+) {
+	for (const questionSet of questionSets) {
+		const mandatoryQuestionCount = getMandatoryQuestionCount(questionSet);
+		if (mandatoryQuestionCount > questionSet.max_questions_allowed_to_attempt) {
+			return `Question set '${questionSet.title}' has ${mandatoryQuestionCount} mandatory question(s), but only ${questionSet.max_questions_allowed_to_attempt} question(s) can be attempted.`;
+		}
+	}
+
+	return null;
+}
 
 export const testSchema = z.object({
 	name: z.string(),


### PR DESCRIPTION
## Why
A section should not be saved if candidates must answer more mandatory questions than the section allows them to attempt.

## What
- Preserves `is_mandatory` in section question previews used by the form.
- Blocks save when a question set has mandatory questions above its attempt limit.
- Shows the same warning in the portal UI before submit.
- Adds targeted tests for the server action and section warning.

## Review
- Try a section with 2 mandatory questions and attempt limit 1; Save should be disabled/blocked with a clear message.
- Try a valid section; existing create/update flow should be unchanged.
- Confirm this only affects portal creation/edit validation, not candidate test-taking behavior.

## Tests
- `pnpm vitest run "src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts" "src/routes/(admin)/tests/test-[type]/[id]/SectionedQuestionSets.svelte.test.ts"`
- `pnpm exec prettier --check "src/routes/(admin)/tests/test-[type]/[id]/schema.ts" "src/routes/(admin)/tests/test-[type]/[id]/+page.server.ts" "src/routes/(admin)/tests/test-[type]/[id]/+page.svelte" "src/routes/(admin)/tests/test-[type]/[id]/SectionedQuestionSets.svelte" "src/routes/(admin)/tests/test-[type]/[id]/SectionedQuestionSets.svelte.test.ts" "src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts"`

Note: full `pnpm check` and changed-file eslint are currently blocked by existing repo-wide diagnostics unrelated to this PR, including missing env typings and older `any`/navigation lint violations in the touched route files.