### PR TITLE
Enhance Matrix Match functionality by filtering out empty rows and columns 

### DIFF
--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
@@ -165,17 +165,10 @@
 			) {
 				$formData.options = [];
 			} else if ($formData.question_type === QuestionTypeEnum.MatrixMatch) {
-				// Only include items that have content (text, existing media, or staged media)
-				const rowsWithContent = matrixLeftItems.filter((item) =>
-					hasContent(item.value, item.id, optionMediaMap, stagedOptionFiles, stagedOptionUrls)
-				);
-				const colsWithContent = matrixRightItems.filter((item) =>
-					hasContent(item.value, item.id, optionMediaMap, stagedOptionFiles, stagedOptionUrls)
-				);
 				$formData.options = {
 					rows: {
 						label: matrixRowLabel,
-						items: rowsWithContent.map(({ id, key, value }) => {
+						items: matrixAnswerRowItems.map(({ id, key, value }) => {
 							const media = stripMediaUrl(optionMediaMap[id]);
 							return {
 								id,
@@ -187,7 +180,7 @@
 					},
 					columns: {
 						label: matrixColLabel,
-						items: colsWithContent.map(({ id, key, value }) => {
+						items: matrixAnswerColItems.map(({ id, key, value }) => {
 							const media = stripMediaUrl(optionMediaMap[id]);
 							return {
 								id,
@@ -198,7 +191,13 @@
 						})
 					}
 				};
-				$formData.correct_answer = matrixMatches;
+				const contentRowIds = new Set(matrixAnswerRowItems.map((item) => String(item.id)));
+				const contentColIds = new Set(matrixAnswerColItems.map((item) => item.id));
+				$formData.correct_answer = Object.fromEntries(
+					Object.entries(matrixMatches)
+						.filter(([key]) => contentRowIds.has(key))
+						.map(([key, ids]) => [key, ids.filter((id) => contentColIds.has(id))])
+				);
 			} else if ($formData.question_type === QuestionTypeEnum.MatrixRating) {
 				$formData.options = {
 					rows: {
@@ -342,6 +341,16 @@
 		}
 	}
 	const isMultiChoice = $derived(totalOptions.filter((o) => o.correct_answer).length > 1);
+	const matrixAnswerRowItems = $derived(
+		matrixLeftItems.filter((item) =>
+			hasContent(item.value, item.id, optionMediaMap, stagedOptionFiles, stagedOptionUrls)
+		)
+	);
+	const matrixAnswerColItems = $derived(
+		matrixRightItems.filter((item) =>
+			hasContent(item.value, item.id, optionMediaMap, stagedOptionFiles, stagedOptionUrls)
+		)
+	);
 
 	// Media state
 	let questionMedia = $state<TMedia | null>(questionData?.media ?? null);
@@ -663,16 +672,9 @@
 		}
 
 		if (type === QuestionTypeEnum.MatrixMatch) {
-			// Filter to items that have content (text or media)
-			const leftWithContent = matrixLeftItems.filter((i) =>
-				hasContent(i.value, i.id, optionMediaMap, stagedOptionFiles, stagedOptionUrls)
-			);
-			const rightWithContent = matrixRightItems.filter((i) =>
-				hasContent(i.value, i.id, optionMediaMap, stagedOptionFiles, stagedOptionUrls)
-			);
 			// Need at least 2 items on each side, and all content items must have matches
-			const allMatched = leftWithContent.every((i) => matrixMatches[String(i.id)]?.length);
-			return leftWithContent.length < 2 || rightWithContent.length < 2 || !allMatched;
+			const allMatched = matrixAnswerRowItems.every((i) => matrixMatches[String(i.id)]?.length);
+			return matrixAnswerRowItems.length < 2 || matrixAnswerColItems.length < 2 || !allMatched;
 		}
 
 		if (type === QuestionTypeEnum.MatrixRating) {
@@ -1350,7 +1352,7 @@
 										<thead>
 											<tr>
 												<th class="px-4 py-3 text-left"></th>
-												{#each matrixRightItems as rightItem (rightItem.id)}
+												{#each matrixAnswerColItems as rightItem (rightItem.id)}
 													<th class="text-primary px-4 py-3 text-center text-sm font-semibold"
 														>{rightItem.key}</th
 													>
@@ -1358,12 +1360,12 @@
 											</tr>
 										</thead>
 										<tbody>
-											{#each matrixLeftItems as leftItem (leftItem.key)}
+											{#each matrixAnswerRowItems as leftItem (leftItem.key)}
 												<tr class="border-border border-t">
 													<td class="text-primary px-4 py-4 text-sm font-semibold"
 														>{leftItem.key}</td
 													>
-													{#each matrixRightItems as rightItem (rightItem.id)}
+													{#each matrixAnswerColItems as rightItem (rightItem.id)}
 														{@const checked = (matrixMatches[String(leftItem.id)] ?? []).includes(
 															rightItem.id
 														)}

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
@@ -1931,6 +1931,152 @@ describe('Single Question Page - Matrix Match Question Type', () => {
 			expect(screen.getByDisplayValue('Column B')).toBeInTheDocument();
 		});
 	});
+
+	describe('Matrix Match Empty Row/Column Filtering', () => {
+		it('should not show empty rows in the answer selector table', () => {
+			render(SingleQuestionPage, {
+				data: {
+					...baseData,
+					questionData: {
+						question_text: 'Match the following',
+						question_type: QuestionTypeEnum.MatrixMatch,
+						options: {
+							rows: {
+								label: 'Column A',
+								items: [
+									{ id: 1, key: 'A', value: 'India' },
+									{ id: 2, key: 'B', value: 'France' },
+									{ id: 3, key: 'C', value: '' }
+								]
+							},
+							columns: {
+								label: 'Column B',
+								items: [
+									{ id: 10, key: '1', value: 'New Delhi' },
+									{ id: 11, key: '2', value: 'Paris' }
+								]
+							}
+						},
+						correct_answer: { '1': [10], '2': [11] },
+						is_mandatory: false,
+						is_active: true,
+						marking_scheme: { correct: 1, wrong: 0, skipped: 0 }
+					}
+				} as any
+			});
+
+			const checkboxes = screen.getAllByRole('checkbox');
+			expect(checkboxes.length).toBe(4);
+		});
+
+		it('should not show empty columns in the answer selector table', () => {
+			render(SingleQuestionPage, {
+				data: {
+					...baseData,
+					questionData: {
+						question_text: 'Match the following',
+						question_type: QuestionTypeEnum.MatrixMatch,
+						options: {
+							rows: {
+								label: 'Column A',
+								items: [
+									{ id: 1, key: 'A', value: 'India' },
+									{ id: 2, key: 'B', value: 'France' }
+								]
+							},
+							columns: {
+								label: 'Column B',
+								items: [
+									{ id: 10, key: '1', value: 'New Delhi' },
+									{ id: 11, key: '2', value: 'Paris' },
+									{ id: 12, key: '3', value: '' }
+								]
+							}
+						},
+						correct_answer: { '1': [10], '2': [11] },
+						is_mandatory: false,
+						is_active: true,
+						marking_scheme: { correct: 1, wrong: 0, skipped: 0 }
+					}
+				} as any
+			});
+
+			const checkboxes = screen.getAllByRole('checkbox');
+			expect(checkboxes.length).toBe(4);
+		});
+
+		it('should enable Save when all content rows have matches, even if correct_answer has stale entries for empty rows', () => {
+			render(SingleQuestionPage, {
+				data: {
+					...baseData,
+					questionData: {
+						question_text: 'Match the following',
+						question_type: QuestionTypeEnum.MatrixMatch,
+						options: {
+							rows: {
+								label: 'Column A',
+								items: [
+									{ id: 1, key: 'A', value: 'India' },
+									{ id: 2, key: 'B', value: 'France' },
+									{ id: 3, key: 'C', value: '' }
+								]
+							},
+							columns: {
+								label: 'Column B',
+								items: [
+									{ id: 10, key: '1', value: 'New Delhi' },
+									{ id: 11, key: '2', value: 'Paris' }
+								]
+							}
+						},
+
+						correct_answer: { '1': [10], '2': [11], '3': [10] },
+						is_mandatory: false,
+						is_active: true,
+						marking_scheme: { correct: 1, wrong: 0, skipped: 0 }
+					}
+				} as any
+			});
+
+			expect(screen.getByRole('button', { name: /Save/i })).toBeEnabled();
+		});
+
+		it('should disable Save when a content row has no match, even if an empty row has a stale match', () => {
+			render(SingleQuestionPage, {
+				data: {
+					...baseData,
+					questionData: {
+						question_text: 'Match the following',
+						question_type: QuestionTypeEnum.MatrixMatch,
+						options: {
+							rows: {
+								label: 'Column A',
+								items: [
+									{ id: 1, key: 'A', value: 'India' },
+									{ id: 2, key: 'B', value: 'France' },
+									{ id: 3, key: 'C', value: '' }
+								]
+							},
+							columns: {
+								label: 'Column B',
+								items: [
+									{ id: 10, key: '1', value: 'New Delhi' },
+									{ id: 11, key: '2', value: 'Paris' }
+								]
+							}
+						},
+
+						correct_answer: { '1': [10], '3': [11] },
+						is_mandatory: false,
+						is_active: true,
+						marking_scheme: { correct: 1, wrong: 0, skipped: 0 }
+					}
+				} as any
+			});
+
+			expect(screen.getByRole('button', { name: /Save/i })).toBeDisabled();
+		});
+	});
 });
 
 describe('Single Question Page - Media', () => {
@@ -2213,11 +2359,15 @@ describe('Single Question Page - Matrix Key Scheme', () => {
 				btn.textContent?.includes('Add Row')
 			)!;
 			await fireEvent.click(addRowButton);
-			// New right item key '3' appears in the correct answers table header
-			const keyElements = Array.from(container.querySelectorAll('th')).filter(
+
+			const allInputs = screen.getAllByRole('textbox');
+			const newRightInput = allInputs[allInputs.length - 1];
+			await fireEvent.input(newRightInput, { target: { value: 'Option 3' } });
+
+			const thElements = Array.from(container.querySelectorAll('th')).filter(
 				(el) => el.textContent?.trim() === '3'
 			);
-			expect(keyElements.length).toBeGreaterThanOrEqual(1);
+			expect(thElements.length).toBeGreaterThanOrEqual(1);
 		});
 
 		it('should use left item ID as correct_answer key when match is toggled', async () => {


### PR DESCRIPTION
fixes :- #376 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Matrix Match validation now filters empty rows and columns from answer tables and save operations
  * Save button correctly ignores stale answer entries when content is empty
  * Correct answers table UI displays only populated rows and columns

* **Tests**
  * Added test coverage for empty row/column filtering in Matrix Match
  * Expanded tests for save button enable/disable behavior with content validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->