### PR TITLE
Retaining Tag Type Details During Test Creation and Updation

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/+page.server.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/+page.server.ts
@@ -287,6 +287,8 @@ export const actions: Actions = {
 		// question_revisions is a client-side mirror for UI rendering (full objects with
 		// media URLs). The backend uses question_revision_ids; strip the heavy field.
 		delete transformedFormData.question_revisions;
+		// tag_type_ids is UI-only state for filtering the tag picker; never sent to the backend.
+		delete transformedFormData.tag_type_ids;
 
 		if (isSectionedTest) {
 			delete transformedFormData.question_revision_ids;

--- a/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
@@ -107,6 +107,16 @@
 				id: String(tag.id),
 				name: tag.name
 			})) || [];
+		const tagTypeMap = new Map<string, { id: string; name: string }>();
+		(td?.tags as any[])?.forEach((tag: any) => {
+			if (tag?.tag_type?.id) {
+				tagTypeMap.set(String(tag.tag_type.id), {
+					id: String(tag.tag_type.id),
+					name: tag.tag_type.name
+				});
+			}
+		});
+		$formData.tag_type_ids = Array.from(tagTypeMap.values());
 		$formData.question_revision_ids =
 			td?.question_revisions?.map((q: { id: number }) => q.id) || [];
 		$formData.question_revisions = td?.question_revisions || [];

--- a/src/routes/(admin)/tests/test-[type]/[id]/Primary.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/Primary.svelte
@@ -36,7 +36,11 @@
 		selectedTemplateId?: string | null;
 	} = $props();
 	let selectedStates = $derived($formData.state_ids || []);
-	let selectedTagTypes: { id: string; name: string }[] = $state([]);
+	let selectedTagTypes: { id: string; name: string }[] = $state($formData.tag_type_ids || []);
+
+	$effect(() => {
+		$formData.tag_type_ids = selectedTagTypes;
+	});
 
 	// for State admins, auto-assign their state
 	$effect(() => {

--- a/src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/page.server.test.ts
@@ -95,6 +95,7 @@ const mockValidFormData = {
 	question_pagination: 0,
 	template_id: null,
 	tag_ids: [{ id: 'tag1', name: 'Tag 1' }],
+	tag_type_ids: [{ id: 'type1', name: 'Subject' }],
 	question_revision_ids: [1, 2],
 	question_sets: [],
 	state_ids: [{ id: 'state1', name: 'State 1' }],
@@ -939,6 +940,63 @@ describe('Test Create/Update Page — save action', () => {
 					question_revision_ids: [1]
 				})
 			]);
+		});
+
+		it('strips tag_type_ids from the POST body on create', async () => {
+			(superValidate as any).mockResolvedValue({ valid: true, data: mockValidFormData });
+			mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+			await actions.save({
+				request: mockRequest,
+				params: { type: 'session', id: 'new' },
+				cookies: mockCookies
+			} as any);
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+			expect(body).not.toHaveProperty('tag_type_ids');
+		});
+
+		it('strips tag_type_ids from the PUT body on update', async () => {
+			(superValidate as any).mockResolvedValue({ valid: true, data: mockValidFormData });
+			mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+			await actions.save({
+				request: mockRequest,
+				params: { type: 'session', id: '42' },
+				cookies: mockCookies
+			} as any);
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+			expect(body).not.toHaveProperty('tag_type_ids');
+		});
+
+		it('still sends tag_ids as plain id strings when tag_type_ids is present', async () => {
+			(superValidate as any).mockResolvedValue({ valid: true, data: mockValidFormData });
+			mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+			await actions.save({
+				request: mockRequest,
+				params: { type: 'session', id: 'new' },
+				cookies: mockCookies
+			} as any);
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+			expect(body.tag_ids).toEqual(['tag1']);
+		});
+
+		it('still sends state_ids and district_ids as plain id strings when tag_type_ids is present', async () => {
+			(superValidate as any).mockResolvedValue({ valid: true, data: mockValidFormData });
+			mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+			await actions.save({
+				request: mockRequest,
+				params: { type: 'session', id: 'new' },
+				cookies: mockCookies
+			} as any);
+
+			const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+			expect(body.state_ids).toEqual(['state1']);
+			expect(body.district_ids).toEqual(['district1']);
 		});
 
 		it('converts empty string start_time to null', async () => {

--- a/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
@@ -56,6 +56,7 @@ const defaultFormValues = {
 	state_ids: [],
 	district_ids: [],
 	tag_ids: [],
+	tag_type_ids: [],
 	marking_scheme: { correct: 1, wrong: 0, skipped: 0 },
 	marks_level: 'question',
 	shuffle: false,
@@ -569,6 +570,134 @@ describe('Test Create/Update Page', () => {
 			await fireEvent.click(getBottomNextButton()); // step 1 → step 2
 
 			expect(getBottomNextButton()).not.toBeDisabled();
+		});
+	});
+
+	// ── tag_type_ids population ───────────────────────────────────────────────
+
+	describe('populateFormFromTestData — tag_type_ids', () => {
+		it('derives tag_type_ids from tags with nested tag_type objects', () => {
+			const formStore = setupSuperFormMock();
+			const testData = {
+				id: '42',
+				name: 'Test',
+				description: '',
+				question_revisions: [],
+				question_sets: [],
+				states: [],
+				districts: [],
+				tags: [
+					{ id: '1', name: 'Physics', tag_type: { id: '10', name: 'Subject' } },
+					{ id: '2', name: 'Algebra', tag_type: { id: '20', name: 'Topic' } }
+				],
+				random_tag_counts: []
+			};
+			render(TestCreatePage, { data: baseData({ testData }) });
+
+			const stored = get(formStore);
+			expect(stored.tag_type_ids).toEqual([
+				{ id: '10', name: 'Subject' },
+				{ id: '20', name: 'Topic' }
+			]);
+		});
+
+		it('deduplicates tag_type_ids when multiple tags share the same tag_type', () => {
+			const formStore = setupSuperFormMock();
+			const testData = {
+				id: '42',
+				name: 'Test',
+				description: '',
+				question_revisions: [],
+				question_sets: [],
+				states: [],
+				districts: [],
+				tags: [
+					{ id: '1', name: 'Physics', tag_type: { id: '10', name: 'Subject' } },
+					{ id: '2', name: 'Chemistry', tag_type: { id: '10', name: 'Subject' } }
+				],
+				random_tag_counts: []
+			};
+			render(TestCreatePage, { data: baseData({ testData }) });
+
+			const stored = get(formStore);
+			expect(stored.tag_type_ids).toHaveLength(1);
+			expect(stored.tag_type_ids).toEqual([{ id: '10', name: 'Subject' }]);
+		});
+
+		it('produces empty tag_type_ids when tags have no tag_type field', () => {
+			const formStore = setupSuperFormMock();
+			const testData = {
+				id: '42',
+				name: 'Test',
+				description: '',
+				question_revisions: [],
+				question_sets: [],
+				states: [],
+				districts: [],
+				tags: [
+					{ id: '1', name: 'Physics' },
+					{ id: '2', name: 'Algebra' }
+				],
+				random_tag_counts: []
+			};
+			render(TestCreatePage, { data: baseData({ testData }) });
+
+			expect(get(formStore).tag_type_ids).toEqual([]);
+		});
+
+		it('produces empty tag_type_ids when tags array is empty', () => {
+			const formStore = setupSuperFormMock();
+			const testData = {
+				id: '42',
+				name: 'Test',
+				description: '',
+				question_revisions: [],
+				question_sets: [],
+				states: [],
+				districts: [],
+				tags: [],
+				random_tag_counts: []
+			};
+			render(TestCreatePage, { data: baseData({ testData }) });
+
+			expect(get(formStore).tag_type_ids).toEqual([]);
+		});
+
+		it('defaults tag_type_ids to empty array for a new test (no testData)', () => {
+			const formStore = setupSuperFormMock();
+			render(TestCreatePage, { data: baseData({ testData: null }) });
+
+			expect(get(formStore).tag_type_ids).toEqual([]);
+		});
+
+		it('tag_type_ids persists in the form store after navigating to step 2 and back', async () => {
+			const formStore = setupSuperFormMock({ name: 'Test', description: 'Desc' });
+			const testData = {
+				id: '42',
+				name: 'Test',
+				description: 'Desc',
+				question_revisions: [],
+				question_sets: [],
+				states: [],
+				districts: [],
+				tags: [{ id: '1', name: 'Physics', tag_type: { id: '10', name: 'Subject' } }],
+				random_tag_counts: []
+			};
+			render(TestCreatePage, { data: baseData({ testData }) });
+
+			// tag_type_ids set from testData
+			expect(get(formStore).tag_type_ids).toEqual([{ id: '10', name: 'Subject' }]);
+
+			await fireEvent.click(getBottomNextButton()); // step 1 → step 2
+
+			// Still intact in the store on step 2
+			expect(get(formStore).tag_type_ids).toEqual([{ id: '10', name: 'Subject' }]);
+
+			const prevButtons = screen.getAllByText('Previous');
+			await fireEvent.click(prevButtons[prevButtons.length - 1]); // step 2 → step 1
+
+			// Still intact after returning to step 1
+			expect(get(formStore).tag_type_ids).toEqual([{ id: '10', name: 'Subject' }]);
 		});
 	});
 });

--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { testSchema } from './schema';
+
+const minimalValid = {
+	name: 'Test',
+	description: '',
+	marking_scheme: { correct: 1, wrong: 0, skipped: 0 },
+	certificate_id: null
+};
+
+describe('testSchema — tag_type_ids', () => {
+	it('accepts a valid tag_type_ids array', () => {
+		const result = testSchema.safeParse({
+			...minimalValid,
+			tag_type_ids: [{ id: '1', name: 'Subject' }]
+		});
+		expect(result.success).toBe(true);
+		expect(result.data?.tag_type_ids).toEqual([{ id: '1', name: 'Subject' }]);
+	});
+
+	it('defaults tag_type_ids to empty array when omitted', () => {
+		const result = testSchema.safeParse(minimalValid);
+		expect(result.success).toBe(true);
+		expect(result.data?.tag_type_ids).toEqual([]);
+	});
+
+	it('includes tag_type_ids in parsed output so server-side delete is the only stripping mechanism', () => {
+		const result = testSchema.safeParse({
+			...minimalValid,
+			tag_type_ids: [{ id: '5', name: 'Topic' }]
+		});
+		expect(result.success).toBe(true);
+		expect(result.data).toHaveProperty('tag_type_ids');
+	});
+});

--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
@@ -97,6 +97,7 @@ export const testSchema = z.object({
 	is_template: z.boolean().default(false),
 	template_id: z.string().nullable().optional(),
 	tag_ids: z.array(z.object({ id: z.string(), name: z.string() })).default([]),
+	tag_type_ids: z.array(z.object({ id: z.string(), name: z.string() })).default([]),
 	question_revision_ids: z.array(z.number()).default([]),
 	question_sets: z.array(questionSetSchema).default([]),
 	state_ids: z.array(z.object({ id: z.string(), name: z.string() })).default([]),


### PR DESCRIPTION
Fixes #434 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tag type filtering in the test editor to properly maintain selected tag types in the user interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-portal/pull/436)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->