### PR TITLE
Removal association of State-admin with District

### DIFF
--- a/src/lib/utils/permissions.test.ts
+++ b/src/lib/utils/permissions.test.ts
@@ -11,6 +11,7 @@ import {
 	requireAnyPermission,
 	isStateAdmin,
 	getUserState,
+	hasLocation,
 	PERMISSIONS,
 	type User
 } from './permissions';
@@ -257,6 +258,80 @@ describe('permissions', () => {
 		it('should return null when user.states is undefined', () => {
 			const userWithoutStates = { ...mockUser, states: undefined } as User;
 			expect(getUserState(userWithoutStates)).toBeNull();
+		});
+	});
+
+	describe('hasLocation()', () => {
+		const userWithState: User = {
+			id: 10,
+			username: 'stateuser',
+			email: 'state@example.com',
+			permissions: [],
+			states: [{ id: 1, name: 'Maharashtra' }],
+			districts: []
+		} as User;
+
+		const userWithDistrict: User = {
+			id: 11,
+			username: 'districtuser',
+			email: 'district@example.com',
+			permissions: [],
+			states: [],
+			districts: [{ id: 1, name: 'Pune' }]
+		} as User;
+
+		const userWithBoth: User = {
+			id: 12,
+			username: 'bothuser',
+			email: 'both@example.com',
+			permissions: [],
+			states: [{ id: 1, name: 'Maharashtra' }],
+			districts: [{ id: 1, name: 'Pune' }]
+		} as User;
+
+		const userWithNoLocation: User = {
+			id: 13,
+			username: 'nolocation',
+			email: 'noloc@example.com',
+			permissions: [],
+			states: [],
+			districts: []
+		} as User;
+
+		it('should return false when user is null', () => {
+			expect(hasLocation(null)).toBe(false);
+		});
+
+		it('should return false when user has no states and no districts', () => {
+			expect(hasLocation(userWithNoLocation)).toBe(false);
+		});
+
+		it('should return true when user has one state assigned', () => {
+			expect(hasLocation(userWithState)).toBe(true);
+		});
+
+		it('should return true when user has multiple states assigned', () => {
+			const userWithMultipleStates = {
+				...userWithState,
+				states: [
+					{ id: 1, name: 'Maharashtra' },
+					{ id: 2, name: 'Gujarat' }
+				]
+			} as User;
+			expect(hasLocation(userWithMultipleStates)).toBe(true);
+		});
+
+		it('should return true when user has a district assigned', () => {
+			expect(hasLocation(userWithDistrict)).toBe(true);
+		});
+
+		it('should return true when user has both states and districts assigned', () => {
+			expect(hasLocation(userWithBoth)).toBe(true);
+		});
+
+		it('should return false when states and districts are undefined', () => {
+			const userWithoutLocationFields = { ...mockUser, states: undefined, districts: undefined } as User;
+			expect(hasLocation(userWithoutLocationFields)).toBe(false);
 		});
 	});
 });

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -29,6 +29,14 @@ export function hasAssignedDistricts(user: User | null): boolean {
 }
 
 /**
+ * Check if user has any assigned locations.
+ */
+export function hasLocation(user: User | null): boolean {
+	if (!user) return false;
+	return (user.states?.length ?? 0) > 0 || (user.districts?.length ?? 0) > 0;
+}
+
+/**
  * Get the user's assigned state (for State admins)
  * Returns the first state if user has states assigned, null otherwise
  */

--- a/src/routes/(admin)/questionbank/+page.svelte
+++ b/src/routes/(admin)/questionbank/+page.svelte
@@ -19,7 +19,7 @@
 	import TagTypeSelection from '$lib/components/TagTypeSelection.svelte';
 	import { enhance } from '$app/forms';
 	import { invalidateAll } from '$app/navigation';
-	import { canCreate, canUpdate, canDelete, isStateAdmin } from '$lib/utils/permissions.js';
+	import { canCreate, canUpdate, canDelete, hasLocation } from '$lib/utils/permissions.js';
 	import { useTerms } from '$lib/nomenclature';
 
 	const { data } = $props();
@@ -230,7 +230,7 @@
 			<SearchInput placeholder="Search questions" value={search} />
 
 			<div class="flex flex-1 flex-wrap items-start justify-end gap-2">
-				{#if !isStateAdmin(data.user)}
+				{#if !hasLocation(data.user)}
 					<div>
 						<StateSelection bind:states={filteredStates} filteration={true} />
 					</div>

--- a/src/routes/(admin)/questionbank/+page.svelte.test.ts
+++ b/src/routes/(admin)/questionbank/+page.svelte.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import QuestionListingPage from './+page.svelte';
+
+vi.mock('$app/state', () => ({
+	page: {
+		url: new URL('http://localhost/questionbank'),
+		searchParams: new URLSearchParams()
+	}
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(),
+	invalidateAll: vi.fn()
+}));
+
+vi.mock('$app/paths', () => ({
+	resolve: vi.fn((path: string) => path)
+}));
+
+vi.mock('$app/forms', () => ({
+	enhance: vi.fn(() => () => {})
+}));
+
+vi.mock('$lib/constants', () => ({
+	DEFAULT_PAGE_SIZE: 25
+}));
+
+vi.mock('$lib/utils/permissions.js', () => ({
+	canCreate: vi.fn(() => false),
+	canUpdate: vi.fn(() => false),
+	canDelete: vi.fn(() => false),
+	hasLocation: vi.fn(() => false)
+}));
+
+vi.mock('$lib/components/data-table', () => ({
+	DataTable: vi.fn()
+}));
+
+vi.mock('$lib/components/data-table/BatchActionsToolbar.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+const { mockStateSelection } = vi.hoisted(() => ({
+	mockStateSelection: vi.fn().mockImplementation(() => ({
+		$$set: vi.fn(),
+		$destroy: vi.fn(),
+		$on: vi.fn()
+	}))
+}));
+
+vi.mock('$lib/components/StateSelection.svelte', () => ({ default: mockStateSelection }));
+
+vi.mock('$lib/components/TagsSelection.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+vi.mock('$lib/components/TagTypeSelection.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+vi.mock('$lib/components/DeleteDialog.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+vi.mock('./columns', () => ({
+	createQuestionColumns: vi.fn(() => [])
+}));
+
+import { hasLocation } from '$lib/utils/permissions.js';
+
+const baseData = (items: any[] = []) => ({
+	questions: { items, total: items.length, pages: items.length > 0 ? 1 : 0 },
+	params: { page: 1, size: 25, search: '', sortBy: '', sortOrder: 'asc' },
+	user: { id: 1, permissions: [] }
+});
+
+describe('Question Bank Listing Page', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	describe('Page title', () => {
+		it('should show "Question Bank" title', () => {
+			render(QuestionListingPage, { data: baseData([{ id: '1' }]) });
+			expect(screen.getByText('Question Bank')).toBeInTheDocument();
+		});
+	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	describe('Empty state', () => {
+		it('should show empty state when no items are present', () => {
+			render(QuestionListingPage, { data: baseData([]) });
+			expect(screen.getByText('Create your first question')).toBeInTheDocument();
+		});
+
+		it('should not show empty state when items are present', () => {
+			render(QuestionListingPage, { data: baseData([{ id: '1' }]) });
+			expect(screen.queryByText('Create your first question')).not.toBeInTheDocument();
+		});
+	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	describe('Filter visibility (location-based)', () => {
+		it('should show state filter when user has no location assigned', () => {
+			vi.mocked(hasLocation).mockReturnValue(false);
+			mockStateSelection.mockClear();
+			render(QuestionListingPage, { data: baseData([{ id: '1' }]) });
+			expect(mockStateSelection).toHaveBeenCalled();
+		});
+
+		it('should hide state filter when user has a state assigned', () => {
+			vi.mocked(hasLocation).mockReturnValue(true);
+			mockStateSelection.mockClear();
+			render(QuestionListingPage, { data: baseData([{ id: '1' }]) });
+			expect(mockStateSelection).not.toHaveBeenCalled();
+		});
+
+		it('should hide state filter when user has districts assigned', () => {
+			vi.mocked(hasLocation).mockReturnValue(true);
+			mockStateSelection.mockClear();
+			render(QuestionListingPage, { data: baseData([{ id: '1' }]) });
+			expect(mockStateSelection).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/routes/(admin)/questionbank/page.svelte.test.ts
+++ b/src/routes/(admin)/questionbank/page.svelte.test.ts
@@ -69,12 +69,13 @@ vi.mock('./columns', () => ({
 }));
 
 import { hasLocation } from '$lib/utils/permissions.js';
+import { type Question } from './columns';
 
-const baseData = (items: any[] = []) => ({
+const baseData = (items: Partial<Question>[] = []) => ({
 	questions: { items, total: items.length, pages: items.length > 0 ? 1 : 0 },
 	params: { page: 1, size: 25, search: '', sortBy: '', sortOrder: 'asc' },
 	user: { id: 1, permissions: [] }
-});
+}) as any;
 
 describe('Question Bank Listing Page', () => {
 	beforeEach(() => {

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
@@ -34,7 +34,7 @@
 	import TagTypeSelection from '$lib/components/TagTypeSelection.svelte';
 	import QuestionRevision from './QuestionRevision.svelte';
 	import QuestionPreview from './QuestionPreview.svelte';
-	import { isStateAdmin, getUserState, type User } from '$lib/utils/permissions.js';
+	import { isStateAdmin, getUserState, type User, hasLocation } from '$lib/utils/permissions.js';
 	import { useTerms } from '$lib/nomenclature';
 
 	const term = useTerms();
@@ -1588,7 +1588,7 @@
 				</div>
 
 				<!-- State -->
-				{#if !isStateAdmin(data.user)}
+				{#if !hasLocation(data.user)}
 					<div class="flex flex-col gap-2">
 						<Label class="font-semibold">State</Label>
 						<StateSelection bind:states={$formData.state_ids} />

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
@@ -22,7 +22,8 @@ vi.mock('$lib/components/StateSelection.svelte', () => ({
 
 vi.mock('$lib/utils/permissions.js', () => ({
 	isStateAdmin: vi.fn(() => false),
-	getUserState: vi.fn(() => null)
+	getUserState: vi.fn(() => null),
+	hasLocation: vi.fn(() => false)
 }));
 
 const baseForm = {

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -25,7 +25,8 @@
 		canUpdate,
 		canDelete,
 		isStateAdmin,
-		hasAssignedDistricts
+		hasAssignedDistricts,
+		hasLocation
 	} from '$lib/utils/permissions.js';
 	import { useTerms } from '$lib/nomenclature';
 
@@ -234,13 +235,10 @@
 			/>
 
 			<div class="flex flex-1 flex-wrap items-start justify-end gap-2">
-				{#if !isStateAdmin(data.user)}
+				{#if !hasLocation(data.user)}
 					<div>
 						<StateSelection bind:states={filteredStates} filteration={true} />
 					</div>
-				{/if}
-
-				{#if !hasAssignedDistricts(data.user)}
 					<div>
 						<DistrictSelection
 							bind:districts={filteredDistricts}
@@ -248,9 +246,8 @@
 							filteration={true}
 						/>
 					</div>
+					<div class="mx-4 w-px self-stretch bg-gray-300"></div>
 				{/if}
-
-				<div class="mx-4 w-px self-stretch bg-gray-300"></div>
 
 				<div>
 					<TagTypeSelection bind:tagTypes={filteredTagtypes} filteration={true} />

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -19,15 +19,7 @@
 	import type { Filter } from '$lib/types/filters.js';
 	import TagTypeSelection from '$lib/components/TagTypeSelection.svelte';
 	import DistrictSelection from '$lib/components/DistrictSelection.svelte';
-	import {
-		canCreate,
-		canRead,
-		canUpdate,
-		canDelete,
-		isStateAdmin,
-		hasAssignedDistricts,
-		hasLocation
-	} from '$lib/utils/permissions.js';
+	import { canCreate, canRead, canUpdate, canDelete, hasLocation } from '$lib/utils/permissions.js';
 	import { useTerms } from '$lib/nomenclature';
 
 	const term = useTerms();

--- a/src/routes/(admin)/tests/test-[type]/[id]/Primary.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/Primary.svelte
@@ -13,7 +13,8 @@
 		getUserState,
 		type User,
 		getUserDistrict,
-		hasAssignedDistricts
+		hasAssignedDistricts,
+		hasLocation
 	} from '$lib/utils/permissions.js';
 	import TemplateSelect from './TemplateSelect.svelte';
 	import { useTerms } from '$lib/nomenclature';
@@ -135,25 +136,20 @@
 					<TagsSelection bind:tags={$formData.tag_ids} tagTypes={selectedTagTypes} />
 				</div>
 			</div>
-			{#if !isStateAdmin(user) || !hasAssignedDistricts(user)}
+			{#if !hasLocation(user)}
 				<hr class="border-border my-4" />
-				{#if !isStateAdmin(user)}
-					<div>
-						<Label class="text-sm font-semibold text-gray-800">State</Label>
-						<div class="mt-2">
-							<StateSelection bind:states={$formData.state_ids} />
-						</div>
+				<div>
+					<Label class="text-sm font-semibold text-gray-800">State</Label>
+					<div class="mt-2">
+						<StateSelection bind:states={$formData.state_ids} />
 					</div>
-				{/if}
-
-				{#if !hasAssignedDistricts(user)}
-					<div>
-						<Label class="text-sm font-semibold text-gray-800">District</Label>
-						<div class="mt-2">
-							<DistrictSelection bind:districts={$formData.district_ids} {selectedStates} />
-						</div>
+				</div>
+				<div>
+					<Label class="text-sm font-semibold text-gray-800">District</Label>
+					<div class="mt-2">
+						<DistrictSelection bind:districts={$formData.district_ids} {selectedStates} />
 					</div>
-				{/if}
+				</div>
 			{/if}
 
 			<hr class="border-border my-4" />

--- a/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
@@ -24,7 +24,8 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	canUpdate: vi.fn(() => false),
 	canDelete: vi.fn(() => false),
 	isStateAdmin: vi.fn(() => false),
-	hasAssignedDistricts: vi.fn(() => false)
+	hasAssignedDistricts: vi.fn(() => false),
+	hasLocation: vi.fn(() => false)
 }));
 
 vi.mock('$lib/components/data-table/index.js', () => ({
@@ -33,17 +34,21 @@ vi.mock('$lib/components/data-table/index.js', () => ({
 	DataTable: vi.fn((_, props: any) => void props?.columns)
 }));
 
-vi.mock('$lib/components/StateSelection.svelte', () => ({
-	default: function MockStateSelection() {
-		return { $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() };
-	}
+const { mockStateSelection, mockDistrictSelection } = vi.hoisted(() => ({
+	mockStateSelection: vi.fn().mockImplementation(() => ({
+		$$set: vi.fn(),
+		$destroy: vi.fn(),
+		$on: vi.fn()
+	})),
+	mockDistrictSelection: vi.fn().mockImplementation(() => ({
+		$$set: vi.fn(),
+		$destroy: vi.fn(),
+		$on: vi.fn()
+	}))
 }));
 
-vi.mock('$lib/components/DistrictSelection.svelte', () => ({
-	default: function MockDistrictSelection() {
-		return { $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() };
-	}
-}));
+vi.mock('$lib/components/StateSelection.svelte', () => ({ default: mockStateSelection }));
+vi.mock('$lib/components/DistrictSelection.svelte', () => ({ default: mockDistrictSelection }));
 
 vi.mock('$lib/components/TagsSelection.svelte', () => ({
 	default: function MockTagsSelection() {
@@ -67,7 +72,7 @@ vi.mock('./columns.js', () => ({
 	})
 }));
 
-import { canCreate, canRead, isStateAdmin, hasAssignedDistricts } from '$lib/utils/permissions.js';
+import { canCreate, canRead, hasLocation } from '$lib/utils/permissions.js';
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
 
@@ -189,16 +194,31 @@ describe('Test Management Listing Page', () => {
 			expect(screen.getByPlaceholderText('Search tests...')).toBeInTheDocument();
 		});
 
-		it('should call isStateAdmin to determine state filter visibility', () => {
-			vi.mocked(isStateAdmin).mockReturnValue(false);
+		it('should show state and district filters when user has no location assigned', () => {
+			vi.mocked(hasLocation).mockReturnValue(false);
+			mockStateSelection.mockClear();
+			mockDistrictSelection.mockClear();
 			render(TestListingPage, { data: withItems(false) });
-			expect(isStateAdmin).toHaveBeenCalled();
+			expect(mockStateSelection).toHaveBeenCalled();
+			expect(mockDistrictSelection).toHaveBeenCalled();
 		});
 
-		it('should call hasAssignedDistricts to determine district filter visibility', () => {
-			vi.mocked(hasAssignedDistricts).mockReturnValue(false);
+		it('should hide state and district filters when user has a state assigned', () => {
+			vi.mocked(hasLocation).mockReturnValue(true);
+			mockStateSelection.mockClear();
+			mockDistrictSelection.mockClear();
 			render(TestListingPage, { data: withItems(false) });
-			expect(hasAssignedDistricts).toHaveBeenCalled();
+			expect(mockStateSelection).not.toHaveBeenCalled();
+			expect(mockDistrictSelection).not.toHaveBeenCalled();
+		});
+
+		it('should hide state and district filters when user has districts assigned', () => {
+			vi.mocked(hasLocation).mockReturnValue(true);
+			mockStateSelection.mockClear();
+			mockDistrictSelection.mockClear();
+			render(TestListingPage, { data: withItems(false) });
+			expect(mockStateSelection).not.toHaveBeenCalled();
+			expect(mockDistrictSelection).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/routes/(admin)/users/[action]/[id]/UserForm.svelte
+++ b/src/routes/(admin)/users/[action]/[id]/UserForm.svelte
@@ -69,6 +69,18 @@
 		return label.includes('state') || label.includes('test');
 	});
 
+	const isSelectedRoleStateAdmin = $derived.by(() => {
+		const label =
+			data.roles.find((role: any) => role.id === $formData.role_id)?.label?.toLowerCase() ?? '';
+		return label.includes('state');
+	});
+
+	$effect(() => {
+		if (isSelectedRoleStateAdmin) {
+			selectedDistricts = [];
+		}
+	});
+
 	// if state admin is creating a user with state admin or test admin role,
 	// then we should auto-assign current state admin's state and state admin's districts
 	$effect(() => {
@@ -218,7 +230,7 @@
 						<Form.FieldErrors />
 					</Form.Field>
 				{/if}
-				{#if !currentUserHasAssignedDistricts}
+				{#if !currentUserHasAssignedDistricts && !isSelectedRoleStateAdmin}
 					<Form.Field {form} name="district_ids">
 						<Form.Control>
 							{#snippet children({ props })}

--- a/src/routes/(admin)/users/[action]/[id]/UserForm.svelte
+++ b/src/routes/(admin)/users/[action]/[id]/UserForm.svelte
@@ -219,28 +219,34 @@
 			</Form.Field>
 
 			{#if showLocationFields}
-				{#if !currentUserIsStateAdmin}
-					<Form.Field {form} name="state_ids">
-						<Form.Control>
-							{#snippet children({ props })}
-								<Form.Label class="font-semibold">State</Form.Label>
-								<StateSelection {...props} bind:states={selectedStates} multiple={false} />
-							{/snippet}
-						</Form.Control>
-						<Form.FieldErrors />
-					</Form.Field>
-				{/if}
-				{#if !currentUserHasAssignedDistricts && !isSelectedRoleStateAdmin}
-					<Form.Field {form} name="district_ids">
-						<Form.Control>
-							{#snippet children({ props })}
-								<Form.Label class="font-semibold">District</Form.Label>
-								<DistrictSelection {...props} bind:districts={selectedDistricts} {selectedStates} />
-							{/snippet}
-						</Form.Control>
-						<Form.FieldErrors />
-					</Form.Field>
-				{/if}
+				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+					{#if !currentUserIsStateAdmin}
+						<Form.Field {form} name="state_ids">
+							<Form.Control>
+								{#snippet children({ props })}
+									<Form.Label class="font-semibold">State</Form.Label>
+									<StateSelection {...props} bind:states={selectedStates} multiple={false} />
+								{/snippet}
+							</Form.Control>
+							<Form.FieldErrors />
+						</Form.Field>
+					{/if}
+					{#if !currentUserHasAssignedDistricts && !isSelectedRoleStateAdmin}
+						<Form.Field {form} name="district_ids">
+							<Form.Control>
+								{#snippet children({ props })}
+									<Form.Label class="font-semibold">District</Form.Label>
+									<DistrictSelection
+										{...props}
+										bind:districts={selectedDistricts}
+										{selectedStates}
+									/>
+								{/snippet}
+							</Form.Control>
+							<Form.FieldErrors />
+						</Form.Field>
+					{/if}
+				</div>
 			{/if}
 		</div>
 

--- a/src/routes/(admin)/users/[action]/[id]/UserForm.svelte.test.ts
+++ b/src/routes/(admin)/users/[action]/[id]/UserForm.svelte.test.ts
@@ -251,7 +251,7 @@ describe('UserForm Component', () => {
 	});
 
 	describe('System Admin - State Field Visibility', () => {
-		it('should show state and district field when System Admin selects a state role', () => {
+		it('should show state and not district field when System Admin selects a state role', () => {
 			const data = createTestData(
 				{ role_id: '2' }, // System admin User role
 				{
@@ -263,8 +263,8 @@ describe('UserForm Component', () => {
 			render(UserForm, { data });
 
 			// State field should be visible for System Admin creating State User
-			expect(screen.getByText('State')).toBeInTheDocument();
-			expect(screen.getByText('District')).toBeInTheDocument();
+			expect(screen.queryByText('State')).toBeInTheDocument();
+			expect(screen.queryByText('District')).not.toBeInTheDocument();
 		});
 
 		it('should hide state and district field when State Admin selects a state role', () => {


### PR DESCRIPTION
Fixes #438 and #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced location-based permission checking for consistent authorization across admin pages.

* **Improvements**
  * Updated state and district filter visibility logic in question bank and test management pages.
  * User form now automatically clears district selections when state admin roles are assigned.

* **Tests**
  * Added comprehensive test coverage for location permission functionality and filter visibility behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-portal/pull/444)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->