### PR TITLE
Add test to preserve HTML structure and LaTeX delimiters in RichText …

### DIFF
--- a/src/lib/components/RichText.svelte.test.ts
+++ b/src/lib/components/RichText.svelte.test.ts
@@ -64,6 +64,18 @@ describe('RichText', () => {
 			expect(container.querySelector('.rich-text')?.textContent).toBe('');
 			expect(container.querySelector('.rich-text')?.children.length).toBe(0);
 		});
+
+		it('preserves HTML structure and LaTeX delimiters in imported question content', () => {
+			const { container } = render(RichText, {
+				content: '<p>The moment is \\(Ni^{2+}\\)</p>'
+			});
+
+			expect(container.querySelector('p')).toBeInTheDocument();
+
+			expect(container.querySelector('.rich-text')?.textContent).toContain('The moment is');
+
+			expect(container.querySelector('.rich-text')?.innerHTML).toContain('\\(Ni^{2+}\\)');
+		});
 	});
 
 	describe('MathJax typesetting', () => {


### PR DESCRIPTION
fixes :- #448 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for RichText component rendering to verify HTML structure and LaTeX delimiter preservation in imported content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sashakt-platform/sashakt-portal/pull/453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->