### PR TITLE
Accept organization settings schema v6 with external_login

### DIFF
--- a/src/routes/(admin)/organization/settings/schema.test.ts
+++ b/src/routes/(admin)/organization/settings/schema.test.ts
@@ -9,7 +9,7 @@ import { MAX_NOMENCLATURE_LABEL_LEN, NOMENCLATURE_DEFAULTS } from '$lib/nomencla
 
 function validBaseSettings() {
 	return {
-		version: 5,
+		version: 6,
 		test_timings: {
 			mode: 'fixed',
 			value: { time_limit: 60, start_time: '09:00:00', end_time: '17:00:00' }
@@ -21,6 +21,7 @@ function validBaseSettings() {
 		mark_for_review: { mode: 'fixed', value: { default: true } },
 		omr_mode: { mode: 'fixed', value: { default: false } },
 		pause_test: { mode: 'fixed', value: { default: false } },
+		external_login: { mode: 'fixed', value: { enabled: false, block_anonymous_starts: false } },
 		pre_test_instructions: { value: { text: null } },
 		completion_message: { value: { text: null } },
 		platform_nomenclature: {
@@ -100,9 +101,9 @@ describe('organizationSettingsSchema — platform_nomenclature', () => {
 		expect(result.success).toBe(false);
 	});
 
-	it('pins version to literal 5', () => {
+	it('pins version to literal 6', () => {
 		const settings = validBaseSettings();
-		settings.version = 2 as 5; // wrong version
+		settings.version = 2 as 6; // wrong version
 		const result = organizationSettingsSchema.safeParse(settings);
 		expect(result.success).toBe(false);
 	});

--- a/src/routes/(admin)/organization/settings/schema.ts
+++ b/src/routes/(admin)/organization/settings/schema.ts
@@ -80,6 +80,14 @@ const pauseTestSchema = z.object({
 	})
 });
 
+const externalLoginSchema = z.object({
+	mode: z.literal('fixed').default('fixed'),
+	value: z.object({
+		enabled: z.boolean().default(false),
+		block_anonymous_starts: z.boolean().default(false)
+	})
+});
+
 const nomenclatureLabelSchema = z
 	.string()
 	.max(MAX_NOMENCLATURE_LABEL_LEN, {
@@ -137,7 +145,7 @@ const completionMessageSchema = z.object({
 });
 
 export const organizationSettingsSchema = z.object({
-	version: z.literal(5).default(5),
+	version: z.literal(6).default(6),
 	test_timings: testTimingsSchema,
 	questions_per_page: questionsPerPageSchema,
 	marking_scheme: markingSchemeSchema,
@@ -146,6 +154,7 @@ export const organizationSettingsSchema = z.object({
 	mark_for_review: markForReviewSchema,
 	omr_mode: omrModeSchema,
 	pause_test: pauseTestSchema,
+	external_login: externalLoginSchema,
 	pre_test_instructions: preTestInstructionsSchema,
 	completion_message: completionMessageSchema,
 	platform_nomenclature: platformNomenclatureSchema,


### PR DESCRIPTION
## Summary
- Updates Portal organization settings schema from version 5 to version 6.
- Adds the `external_login` setting (`{ enabled, block_anonymous_starts }`) to the schema so Portal validates and preserves it round-trip.
- No new Portal settings-form UI is added for external login — it is org-scoped / backend-managed, like `platform_guide` and `analytics_link`.
- Keeps Portal compatible with the sashakt-core external-login settings migration (v5 → v6).

## How to review
- Schema/test compatibility for sashakt-core#513.
- Confirm no organization settings UI behavior changes are introduced.

## Tested
- `pnpm vitest run "src/routes/(admin)/organization/settings/schema.test.ts"` (23 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external login settings, including options to enable the feature and block anonymous starts.
* **Improvements**
  * Updated organization settings to version 6.
* **Tests**
  * Updated validation coverage for the new external login defaults and settings version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->