### PR TITLE
Replace Delayed save with Immediate save on Blur for text options

### DIFF
--- a/src/routes/(admin)/forms/[action]/[id]/InlineFieldCard.svelte
+++ b/src/routes/(admin)/forms/[action]/[id]/InlineFieldCard.svelte
@@ -302,7 +302,7 @@
 		<div class="grid grid-cols-2 gap-6">
 			<div class="flex flex-col gap-2">
 				<Label class="font-semibold">Field Label</Label>
-				<Input bind:value={label} placeholder="Enter a label" onblur={debouncedSave} />
+				<Input bind:value={label} placeholder="Enter a label" onblur={saveField} />
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label class="font-semibold">
@@ -315,7 +315,7 @@
 					bind:value={name}
 					placeholder="Enter database label"
 					oninput={() => (nameManuallyEdited = true)}
-					onblur={debouncedSave}
+					onblur={saveField}
 				/>
 			</div>
 		</div>
@@ -326,7 +326,7 @@
 				<Input
 					bind:value={placeholder}
 					placeholder="Enter placeholder text for the input field"
-					onblur={debouncedSave}
+					onblur={saveField}
 				/>
 			</div>
 			<div class="flex flex-col gap-2">
@@ -334,7 +334,7 @@
 				<Input
 					bind:value={helpText}
 					placeholder="Enter placeholder text for the input field"
-					onblur={debouncedSave}
+					onblur={saveField}
 				/>
 			</div>
 		</div>
@@ -442,7 +442,7 @@
 										bind:value={minLength}
 										placeholder="Enter minimum length"
 										min="0"
-										onblur={debouncedSave}
+										onblur={saveField}
 									/>
 								</div>
 								<div class="flex flex-col gap-2">
@@ -452,7 +452,7 @@
 										bind:value={maxLength}
 										placeholder="Enter maximum length"
 										min="0"
-										onblur={debouncedSave}
+										onblur={saveField}
 									/>
 								</div>
 							</div>
@@ -466,7 +466,7 @@
 										type="number"
 										bind:value={minValue}
 										placeholder="Enter minimum value"
-										onblur={debouncedSave}
+										onblur={saveField}
 									/>
 								</div>
 								<div class="flex flex-col gap-2">
@@ -475,7 +475,7 @@
 										type="number"
 										bind:value={maxValue}
 										placeholder="Enter maximum value"
-										onblur={debouncedSave}
+										onblur={saveField}
 									/>
 								</div>
 							</div>
@@ -487,7 +487,7 @@
 								<Input
 									bind:value={customErrorMessage}
 									placeholder="Enter error message for the input field"
-									onblur={debouncedSave}
+									onblur={saveField}
 								/>
 							</div>
 							<div class="flex flex-col gap-2">
@@ -495,7 +495,7 @@
 									Pattern
 									<span class="text-muted-foreground font-normal">(Regex)</span>
 								</Label>
-								<Input bind:value={pattern} placeholder="e.g. ^[a-zA-Z]+$" onblur={debouncedSave} />
+								<Input bind:value={pattern} placeholder="e.g. ^[a-zA-Z]+$" onblur={saveField} />
 							</div>
 						</div>
 					</div>

--- a/src/routes/(admin)/forms/[action]/[id]/InlineFieldCard.svelte
+++ b/src/routes/(admin)/forms/[action]/[id]/InlineFieldCard.svelte
@@ -146,8 +146,6 @@
 		return fieldData;
 	}
 
-	// Debounced save with abort support
-	let saveTimeout: ReturnType<typeof setTimeout>;
 	let saveController: AbortController | null = null;
 
 	async function saveField() {
@@ -177,15 +175,9 @@
 		}
 	}
 
-	function debouncedSave() {
-		clearTimeout(saveTimeout);
-		saveTimeout = setTimeout(saveField, 800);
-	}
-
 	// Cleanup on unmount
 	$effect(() => {
 		return () => {
-			clearTimeout(saveTimeout);
 			saveController?.abort();
 		};
 	});
@@ -198,7 +190,7 @@
 
 	function handleRequiredToggle(checked: boolean) {
 		isRequired = checked;
-		debouncedSave();
+		saveField();
 	}
 
 	// Options management
@@ -209,7 +201,7 @@
 
 	function removeOption(idx: number) {
 		options = options.filter((_, i) => i !== idx);
-		debouncedSave();
+		saveField();
 	}
 
 	function updateOptionLabel(idx: number, newLabel: string) {
@@ -226,7 +218,6 @@
 			}
 			return opt;
 		});
-		debouncedSave();
 	}
 </script>
 
@@ -349,7 +340,7 @@
 						value={entityTypeId?.toString()}
 						onValueChange={(value) => {
 							entityTypeId = value ? parseInt(value) : null;
-							debouncedSave();
+							saveField();
 						}}
 					>
 						<Select.Trigger class="w-full">
@@ -388,6 +379,7 @@
 								<Input
 									value={option.label}
 									oninput={(e) => updateOptionLabel(idx, e.currentTarget.value)}
+									onblur={saveField}
 									placeholder="Option label"
 									class="flex-1"
 								/>
@@ -397,8 +389,8 @@
 										options = options.map((opt, i) =>
 											i === idx ? { ...opt, value: e.currentTarget.value } : opt
 										);
-										debouncedSave();
 									}}
+									onblur={saveField}
 									class="flex-1"
 									placeholder="Value"
 								/>

--- a/src/routes/(admin)/forms/[action]/[id]/InlineFieldCard.svelte.test.ts
+++ b/src/routes/(admin)/forms/[action]/[id]/InlineFieldCard.svelte.test.ts
@@ -1,0 +1,87 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import InlineFieldCard from './InlineFieldCard.svelte';
+
+vi.mock('$app/forms', () => ({
+	deserialize: vi.fn(() => ({ type: 'success' }))
+}));
+
+vi.mock('$lib/nomenclature', () => ({
+	useTerms: () => (key: string) => key
+}));
+
+vi.mock('svelte-sonner', () => ({
+	toast: { error: vi.fn(), success: vi.fn() }
+}));
+
+// dragHandle is a Svelte action — return a no-op destroy in jsdom
+vi.mock('svelte-dnd-action', () => ({
+	dragHandle: () => ({ destroy: () => {} })
+}));
+
+const baseField = {
+	id: 1,
+	field_type: 'text' as const,
+	label: 'Test Field',
+	name: 'test_field',
+	is_required: false,
+	order: 0,
+	placeholder: null,
+	help_text: null,
+	options: null,
+	validation: null,
+	default_value: null,
+	entity_type_id: null
+};
+
+const defaultProps = {
+	field: baseField,
+	index: 0,
+	entityTypes: [],
+	onDelete: vi.fn(),
+	onDuplicate: vi.fn(),
+	onFieldTypeChange: vi.fn()
+};
+
+describe('InlineFieldCard — helper text saves on blur without debounce', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		global.fetch = vi.fn().mockResolvedValue({
+			text: () => Promise.resolve('{"type":"success"}')
+		});
+	});
+
+	it('calls fetch immediately when helper text input is blurred', async () => {
+		render(InlineFieldCard, { props: defaultProps });
+
+		// Both "Placeholder Text" and "Helper Text" share the same placeholder string.
+		// Helper Text is the second one in the DOM (index 1).
+		const [, helperTextInput] = screen.getAllByPlaceholderText(
+			'Enter placeholder text for the input field'
+		);
+
+		await fireEvent.input(helperTextInput, { target: { value: 'New helper text' } });
+		await fireEvent.blur(helperTextInput);
+
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(fetch).toHaveBeenCalledWith('?/updateField', expect.objectContaining({ method: 'POST' }));
+
+		const body: FormData = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body;
+		const fieldJson = JSON.parse(body.get('field') as string);
+		expect(fieldJson.help_text).toBe('New helper text');
+	});
+
+	it('does not call fetch before the input is blurred', async () => {
+		render(InlineFieldCard, { props: defaultProps });
+
+		const [, helperTextInput] = screen.getAllByPlaceholderText(
+			'Enter placeholder text for the input field'
+		);
+
+		await fireEvent.input(helperTextInput, { target: { value: 'Still typing...' } });
+
+		// No blur fired yet — fetch must not have been called
+		expect(fetch).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
fixes #447 

To replicate the issue , make changes to 'Helper Text' field and without losing focus on that input, save the form by clicking on Submit. The changes made in the 'Helper Text' do not sustain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form field properties (labels, database labels, placeholders, helper text, validation settings, required toggle, option edits, and entity type) now save immediately on blur, giving instant persistence and clearer feedback during editing.

* **Tests**
  * Added tests verifying helper-text (and related field) persistence triggers an immediate save on blur and not while typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->