### PR TITLE
Ensuring Listing table scroll horizontally on Smaller screen

### DIFF
--- a/src/lib/components/data-table/DataTable.svelte
+++ b/src/lib/components/data-table/DataTable.svelte
@@ -192,8 +192,7 @@
 </script>
 
 <div>
-	<div class="overflow-x-auto rounded-2xl border">
-		<Table.Root>
+	<Table.Root>
 			<Table.Header>
 				{#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
 					<Table.Row class="bg-primary-foreground">
@@ -265,7 +264,6 @@
 				{/each}
 			</Table.Body>
 		</Table.Root>
-	</div>
 	<div class="flex flex-col items-center gap-3 py-4 sm:flex-row sm:justify-between sm:gap-2">
 		<div class="text-muted-foreground text-center text-sm sm:flex-1 sm:text-left">
 			{#if enableSelection}

--- a/src/lib/components/data-table/DataTable.svelte.test.ts
+++ b/src/lib/components/data-table/DataTable.svelte.test.ts
@@ -330,6 +330,22 @@ describe('DataTable', () => {
 		});
 	});
 
+	describe('Responsive Layout', () => {
+		it('should have a horizontal scroll wrapper so the table scrolls on small screens', () => {
+			const { container } = render(DataTable, { props: defaultProps });
+
+			const scrollWrapper = container.querySelector('.overflow-x-auto');
+			expect(scrollWrapper).toBeInTheDocument();
+		});
+
+		it('should not clip table overflow at the table-container level', () => {
+			const { container } = render(DataTable, { props: defaultProps });
+
+			const tableContainer = container.querySelector('[data-slot="table-container"]');
+			expect(tableContainer).not.toHaveClass('overflow-hidden');
+		});
+	});
+
 	describe('Accessibility', () => {
 		it('should render table structure', () => {
 			const { container } = render(DataTable, { props: defaultProps });

--- a/src/lib/components/ui/table/table.svelte
+++ b/src/lib/components/ui/table/table.svelte
@@ -12,7 +12,7 @@
 
 <div
 	data-slot="table-container"
-	class="relative w-full overflow-hidden rounded-xl border border-gray-200"
+	class="relative w-full overflow-visible rounded-xl border border-gray-200"
 >
 	<table
 		bind:this={ref}

--- a/src/lib/components/ui/table/table.svelte
+++ b/src/lib/components/ui/table/table.svelte
@@ -12,7 +12,7 @@
 
 <div
 	data-slot="table-container"
-	class="relative w-full overflow-visible rounded-xl border border-gray-200"
+	class="relative w-full overflow-x-auto rounded-xl border border-gray-200"
 >
 	<table
 		bind:this={ref}


### PR DESCRIPTION
Fixes #467 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table overflow handling so horizontally overflowing content displays correctly on smaller screens.

* **Tests**
  * Added responsive layout tests to verify the table container enables horizontal scrolling and does not clip overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->