### PR TITLE
Change Test Filter label from Shared to Others

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -351,7 +351,7 @@
 					<TabsList class="h-auto p-0.5">
 						<TabsTrigger value="all" class="px-2 py-0.5 text-xs">All</TabsTrigger>
 						<TabsTrigger value="true" class="px-2 py-0.5 text-xs">Mine</TabsTrigger>
-						<TabsTrigger value="false" class="px-2 py-0.5 text-xs">Shared</TabsTrigger>
+						<TabsTrigger value="false" class="px-2 py-0.5 text-xs">Others</TabsTrigger>
 					</TabsList>
 				</Tabs>
 			</div>

--- a/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
@@ -457,7 +457,7 @@ describe('Test Management Listing Page', () => {
 			render(TestListingPage, { data: withItems() });
 			expect(screen.getByRole('tab', { name: 'All' })).toBeInTheDocument();
 			expect(screen.getByRole('tab', { name: 'Mine' })).toBeInTheDocument();
-			expect(screen.getByRole('tab', { name: 'Shared' })).toBeInTheDocument();
+			expect(screen.getByRole('tab', { name: 'Others' })).toBeInTheDocument();
 		});
 
 		it('does not render the segmented control for template mode', () => {
@@ -502,10 +502,10 @@ describe('Test Management Listing Page', () => {
 			expect(screen.getByRole('tab', { name: 'Mine' })).toHaveAttribute('data-state', 'active');
 		});
 
-		it('"Shared" button is active when my_tests=false', () => {
+		it('"Others" button is active when my_tests=false', () => {
 			(page as any).url = new URL('http://localhost/tests/test-session?my_tests=false');
 			render(TestListingPage, { data: withItems() });
-			expect(screen.getByRole('tab', { name: 'Shared' })).toHaveAttribute('data-state', 'active');
+			expect(screen.getByRole('tab', { name: 'Others' })).toHaveAttribute('data-state', 'active');
 		});
 
 		it('"All" button is not active when my_tests=true', () => {
@@ -527,9 +527,9 @@ describe('Test Management Listing Page', () => {
 			expect(calledUrl.searchParams.get('my_tests')).toBe('true');
 		});
 
-		it('clicking "Shared" sets my_tests=false in the URL', async () => {
+		it('clicking "Others" sets my_tests=false in the URL', async () => {
 			render(TestListingPage, { data: withItems() });
-			await fireEvent.click(screen.getByRole('tab', { name: 'Shared' }));
+			await fireEvent.click(screen.getByRole('tab', { name: 'Others' }));
 			const [calledUrl] = vi.mocked(goto).mock.calls[0] as [URL, unknown];
 			expect(calledUrl.searchParams.get('my_tests')).toBe('false');
 		});


### PR DESCRIPTION
Fixes #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the non-template filter tab label from "Shared" to "Others" for improved clarity.
  * Updated test coverage to reflect the label change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->