### PR TITLE
Changing default option for shuffle and 'show marks'

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.test.ts
@@ -8,6 +8,20 @@ const minimalValid = {
 	certificate_id: null
 };
 
+describe('testSchema — shuffle and show_marks defaults', () => {
+	it('defaults shuffle to true when omitted', () => {
+		const result = testSchema.safeParse(minimalValid);
+		expect(result.success).toBe(true);
+		expect(result.data?.shuffle).toBe(true);
+	});
+
+	it('defaults show_marks to false when omitted', () => {
+		const result = testSchema.safeParse(minimalValid);
+		expect(result.success).toBe(true);
+		expect(result.data?.show_marks).toBe(false);
+	});
+});
+
 describe('testSchema — tag_type_ids', () => {
 	it('accepts a valid tag_type_ids array', () => {
 		const result = testSchema.safeParse({

--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
@@ -82,7 +82,7 @@ export const testSchema = z.object({
 	start_instructions: z.string().nullable().optional(),
 	link: z.string().nullable().optional(),
 	no_of_attempts: z.number().default(1),
-	shuffle: z.boolean().default(false),
+	shuffle: z.boolean().default(true),
 	random_questions: z.boolean().default(false),
 	no_of_random_questions: z.number().nullable().optional(),
 	random_tag_count: z
@@ -103,7 +103,7 @@ export const testSchema = z.object({
 	question_sets: z.array(questionSetSchema).default([]),
 	state_ids: z.array(z.object({ id: z.string(), name: z.string() })).default([]),
 	district_ids: z.array(z.object({ id: z.string(), name: z.string() })).default([]),
-	show_marks: z.boolean().default(true),
+	show_marks: z.boolean().default(false),
 	show_result: z.boolean().default(true),
 	show_question_palette: z.boolean().default(true),
 	bookmark: z.boolean().default(false),


### PR DESCRIPTION
Fixes #492 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying default test configuration behavior.

* **Changes**
  * Updated default test settings: shuffle is now enabled by default (previously disabled), while show_marks is now disabled by default (previously enabled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->