### PR TITLE
Fix: Unable to Save test if No Form or No Certificate option chosen in Test Config

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.test.ts
@@ -40,6 +40,12 @@ describe('testSchema — form_id', () => {
 		expect(result.success).toBe(true);
 		expect(result.data?.form_id).toBeNull();
 	});
+
+	it('coerces 0 to null', () => {
+		const result = testSchema.safeParse({ ...minimalValid, form_id: 0 });
+		expect(result.success).toBe(true);
+		expect(result.data?.form_id).toBeNull();
+	});
 });
 
 describe('testSchema — certificate_id', () => {
@@ -57,6 +63,12 @@ describe('testSchema — certificate_id', () => {
 
 	it('accepts null when no certificate is set', () => {
 		const result = testSchema.safeParse({ ...minimalValid, certificate_id: null });
+		expect(result.success).toBe(true);
+		expect(result.data?.certificate_id).toBeNull();
+	});
+
+	it('coerces 0 to null', () => {
+		const result = testSchema.safeParse({ ...minimalValid, certificate_id: 0 });
 		expect(result.success).toBe(true);
 		expect(result.data?.certificate_id).toBeNull();
 	});

--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.test.ts
@@ -22,6 +22,46 @@ describe('testSchema — shuffle and show_marks defaults', () => {
 	});
 });
 
+describe('testSchema — form_id', () => {
+	it('coerces empty string to null (No Form selected)', () => {
+		const result = testSchema.safeParse({ ...minimalValid, form_id: '' });
+		expect(result.success).toBe(true);
+		expect(result.data?.form_id).toBeNull();
+	});
+
+	it('coerces numeric string to number when a form is selected', () => {
+		const result = testSchema.safeParse({ ...minimalValid, form_id: '42' });
+		expect(result.success).toBe(true);
+		expect(result.data?.form_id).toBe(42);
+	});
+
+	it('accepts null when no form is set', () => {
+		const result = testSchema.safeParse({ ...minimalValid, form_id: null });
+		expect(result.success).toBe(true);
+		expect(result.data?.form_id).toBeNull();
+	});
+});
+
+describe('testSchema — certificate_id', () => {
+	it('coerces empty string to null (No Certificate selected)', () => {
+		const result = testSchema.safeParse({ ...minimalValid, certificate_id: '' });
+		expect(result.success).toBe(true);
+		expect(result.data?.certificate_id).toBeNull();
+	});
+
+	it('coerces numeric string to number when a certificate is selected', () => {
+		const result = testSchema.safeParse({ ...minimalValid, certificate_id: '7' });
+		expect(result.success).toBe(true);
+		expect(result.data?.certificate_id).toBe(7);
+	});
+
+	it('accepts null when no certificate is set', () => {
+		const result = testSchema.safeParse({ ...minimalValid, certificate_id: null });
+		expect(result.success).toBe(true);
+		expect(result.data?.certificate_id).toBeNull();
+	});
+});
+
 describe('testSchema — tag_type_ids', () => {
 	it('accepts a valid tag_type_ids array', () => {
 		const result = testSchema.safeParse({

--- a/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/schema.ts
@@ -108,10 +108,10 @@ export const testSchema = z.object({
 	show_question_palette: z.boolean().default(true),
 	bookmark: z.boolean().default(false),
 	locale: z.string().default('en-US'),
-	certificate_id: z.coerce.number().nullable(),
+	certificate_id: z.preprocess((v) => (!v ? null : v), z.coerce.number().nullable()),
 	show_feedback_on_completion: z.boolean().default(false),
 	show_feedback_immediately: z.boolean().default(false),
-	form_id: z.coerce.number().nullable().optional(),
+	form_id: z.preprocess((v) => (!v ? null : v), z.coerce.number().nullable().optional()),
 	omr: z.enum(Object.values(OmrMode)).default(OmrMode.NEVER)
 });
 


### PR DESCRIPTION
fixes #500 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for form field validation handling of empty values and null inputs.

* **Bug Fixes**
  * Improved form field validation logic to consistently convert empty inputs to null for form and certificate fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->