### PR TITLE
Configure Test Instructions and Completion Message at Organization settings

### DIFF
--- a/src/lib/utils/organizationSettings.test.ts
+++ b/src/lib/utils/organizationSettings.test.ts
@@ -171,6 +171,46 @@ describe('applyOrgSettingsToNewTestForm', () => {
 		expect(formData.omr).toBe('OPTIONAL');
 	});
 
+	it('copies pre_test_instructions text to start_instructions', () => {
+		const formData: any = {};
+		const s = settings({ pre_test_instructions: { value: { text: '<p>Read carefully</p>' } } });
+		applyOrgSettingsToNewTestForm(formData, s);
+		expect(formData.start_instructions).toBe('<p>Read carefully</p>');
+	});
+
+	it('copies completion_message text to completion_message', () => {
+		const formData: any = {};
+		const s = settings({ completion_message: { value: { text: '<p>Thank you!</p>' } } });
+		applyOrgSettingsToNewTestForm(formData, s);
+		expect(formData.completion_message).toBe('<p>Thank you!</p>');
+	});
+
+	it('sets start_instructions to null when pre_test_instructions text is null', () => {
+		const formData: any = {};
+		const s = settings({ pre_test_instructions: { value: { text: null } } });
+		applyOrgSettingsToNewTestForm(formData, s);
+		expect(formData.start_instructions).toBeNull();
+	});
+
+	it('sets completion_message to null when completion_message text is null', () => {
+		const formData: any = {};
+		const s = settings({ completion_message: { value: { text: null } } });
+		applyOrgSettingsToNewTestForm(formData, s);
+		expect(formData.completion_message).toBeNull();
+	});
+
+	it('sets start_instructions to null when pre_test_instructions is absent', () => {
+		const formData: any = {};
+		applyOrgSettingsToNewTestForm(formData, settings());
+		expect(formData.start_instructions).toBeNull();
+	});
+
+	it('sets completion_message to null when completion_message is absent', () => {
+		const formData: any = {};
+		applyOrgSettingsToNewTestForm(formData, settings());
+		expect(formData.completion_message).toBeNull();
+	});
+
 	it('no-op when settings is null', () => {
 		const formData: any = { time_limit: 999 };
 		applyOrgSettingsToNewTestForm(formData, null);

--- a/src/lib/utils/organizationSettings.ts
+++ b/src/lib/utils/organizationSettings.ts
@@ -50,9 +50,18 @@ export type OrgSettingsPayload = {
 		mode: OrgSettingMode;
 		value: { default: boolean };
 	};
+	pre_test_instructions?: {
+		value: { text: string | null };
+	};
+	completion_message?: {
+		value: { text: string | null };
+	};
 };
 
-type Feature = keyof Omit<OrgSettingsPayload, 'version'>;
+type Feature = keyof Omit<
+	OrgSettingsPayload,
+	'version' | 'pre_test_instructions' | 'completion_message'
+>;
 
 export function isFixed(settings: OrgSettingsPayload | null, feature: Feature): boolean {
 	if (!settings) return false;
@@ -136,4 +145,7 @@ export function applyOrgSettingsToNewTestForm(
 	} else {
 		formData.omr = 'OPTIONAL';
 	}
+
+	formData.start_instructions = settings.pre_test_instructions?.value?.text ?? null;
+	formData.completion_message = settings.completion_message?.value?.text ?? null;
 }

--- a/src/routes/(admin)/organization/settings/+page.server.ts
+++ b/src/routes/(admin)/organization/settings/+page.server.ts
@@ -25,6 +25,12 @@ function normalizeSettingsFromBackend(raw: OrganizationSettings): OrganizationSe
 				end_time: trimSeconds(raw.test_timings.value.end_time)
 			}
 		},
+		pre_test_instructions: {
+			value: { text: raw.pre_test_instructions?.value?.text ?? null }
+		},
+		completion_message: {
+			value: { text: raw.completion_message?.value?.text ?? null }
+		},
 		platform_nomenclature: {
 			mode: raw.platform_nomenclature?.mode ?? 'default',
 			value: fillMissingNomenclatureKeys(raw.platform_nomenclature?.value)

--- a/src/routes/(admin)/organization/settings/OrganizationSettingsForm.svelte
+++ b/src/routes/(admin)/organization/settings/OrganizationSettingsForm.svelte
@@ -14,6 +14,7 @@
 	import OmrModeCard from './cards/OmrModeCard.svelte';
 	import PauseTestCard from './cards/PauseTestCard.svelte';
 	import PlatformNomenclatureCard from './cards/PlatformNomenclatureCard.svelte';
+	import TestInstructionsCard from './cards/TestInstructionsCard.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -60,6 +61,7 @@
 			<MarkForReviewCard bind:settings={$formData} />
 			<OmrModeCard bind:settings={$formData} />
 			<PauseTestCard bind:settings={$formData} />
+			<TestInstructionsCard bind:settings={$formData} />
 			<PlatformNomenclatureCard bind:settings={$formData} />
 		</div>
 	</div>

--- a/src/routes/(admin)/organization/settings/cards/TestInstructionsCard.svelte
+++ b/src/routes/(admin)/organization/settings/cards/TestInstructionsCard.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import RichTextEditor from '$lib/components/RichTextEditor.svelte';
+	import type { OrganizationSettings } from '../schema';
+	import { useTerms } from '$lib/nomenclature';
+
+	const term = useTerms();
+
+	let { settings = $bindable() }: { settings: OrganizationSettings } = $props();
+</script>
+
+<section class="border-border rounded-2xl border bg-white shadow-sm">
+	<header class="px-8 pt-7 pb-6">
+		<h3 class="text-xl font-semibold text-gray-800">Test Instructions</h3>
+		<p class="text-muted-foreground mt-2 text-sm">
+			Default pre-test and completion messages pre-populated when creating a new {term(
+				'test',
+				'lower'
+			)}.
+		</p>
+	</header>
+	<hr class="border-border mx-8" />
+	<div class="flex flex-col gap-6 px-8 py-7">
+		<div>
+			<p class="mb-2 text-sm font-semibold">Pre-test Instructions</p>
+			<RichTextEditor
+				placeholder="E.g., Ensure stable internet. Read each question carefully..."
+				bind:value={settings.pre_test_instructions.value.text}
+			/>
+		</div>
+		<div>
+			<p class="mb-2 text-sm font-semibold">{term('test')} Completion Message</p>
+			<RichTextEditor
+				placeholder="E.g., Thank you for completing the assessment. Your results will be shared soon."
+				bind:value={settings.completion_message.value.text}
+			/>
+		</div>
+	</div>
+</section>

--- a/src/routes/(admin)/organization/settings/page.server.test.ts
+++ b/src/routes/(admin)/organization/settings/page.server.test.ts
@@ -56,6 +56,8 @@ function defaultSettings() {
 		question_palette: { mode: 'fixed', value: { default: true } },
 		mark_for_review: { mode: 'fixed', value: { default: true } },
 		omr_mode: { mode: 'fixed', value: { default: false } },
+		pre_test_instructions: { value: { text: null } },
+		completion_message: { value: { text: null } },
 		platform_guide: { value: { file_path: null } },
 		analytics_link: { value: { url: null } }
 	};
@@ -150,6 +152,53 @@ describe('Organization Settings - load()', () => {
 		});
 
 		await expect(load(mockEvent({ fetch: fetchMock }))).rejects.toMatchObject({ status: 500 });
+	});
+});
+
+describe('Organization Settings - load() normalization of pre_test_instructions & completion_message', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('passes through non-null text values unchanged', async () => {
+		const settings = defaultSettings() as Record<string, unknown>;
+		settings.pre_test_instructions = { value: { text: '<p>Read carefully</p>' } };
+		settings.completion_message = { value: { text: '<p>Thank you!</p>' } };
+
+		const fetchMock = vi.fn().mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ settings })
+		});
+
+		const result = (await load(mockEvent({ fetch: fetchMock }))) as any;
+		expect(result.form.data.pre_test_instructions.value.text).toBe('<p>Read carefully</p>');
+		expect(result.form.data.completion_message.value.text).toBe('<p>Thank you!</p>');
+	});
+
+	it('falls back to null for missing pre_test_instructions from old backend', async () => {
+		const settings = defaultSettings() as Record<string, unknown>;
+		delete settings.pre_test_instructions;
+
+		const fetchMock = vi.fn().mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ settings })
+		});
+
+		const result = (await load(mockEvent({ fetch: fetchMock }))) as any;
+		expect(result.form.data.pre_test_instructions.value.text).toBeNull();
+	});
+
+	it('falls back to null for missing completion_message from old backend', async () => {
+		const settings = defaultSettings() as Record<string, unknown>;
+		delete settings.completion_message;
+
+		const fetchMock = vi.fn().mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ settings })
+		});
+
+		const result = (await load(mockEvent({ fetch: fetchMock }))) as any;
+		expect(result.form.data.completion_message.value.text).toBeNull();
 	});
 });
 
@@ -252,5 +301,30 @@ describe('Organization Settings - actions.save', () => {
 		expect(sentBody.settings.platform_nomenclature.mode).toBe('custom');
 		expect(sentBody.settings.platform_nomenclature.value.tests).toBe('Exams');
 		expect(sentBody.settings.platform_nomenclature.value.user).toBe('Member');
+	});
+
+	it('PUTs pre_test_instructions and completion_message in payload', async () => {
+		const body = defaultSettings() as Record<string, any>;
+		body.test_timings.value.start_time = '09:00';
+		body.test_timings.value.end_time = '17:00';
+		body.pre_test_instructions = { value: { text: '<p>Read carefully</p>' } };
+		body.completion_message = { value: { text: '<p>Thank you!</p>' } };
+
+		const request = new Request('http://localhost', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ ...body, __superform_id: 'x' })
+		});
+		const fetchMock = vi.fn().mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+		try {
+			await actions.save!(mockEvent({ fetch: fetchMock, request }));
+		} catch {
+			/* expected redirect */
+		}
+
+		const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(sentBody.settings.pre_test_instructions.value.text).toBe('<p>Read carefully</p>');
+		expect(sentBody.settings.completion_message.value.text).toBe('<p>Thank you!</p>');
 	});
 });

--- a/src/routes/(admin)/organization/settings/schema.test.ts
+++ b/src/routes/(admin)/organization/settings/schema.test.ts
@@ -9,7 +9,7 @@ import { MAX_NOMENCLATURE_LABEL_LEN, NOMENCLATURE_DEFAULTS } from '$lib/nomencla
 
 function validBaseSettings() {
 	return {
-		version: 4,
+		version: 5,
 		test_timings: {
 			mode: 'fixed',
 			value: { time_limit: 60, start_time: '09:00:00', end_time: '17:00:00' }
@@ -21,6 +21,8 @@ function validBaseSettings() {
 		mark_for_review: { mode: 'fixed', value: { default: true } },
 		omr_mode: { mode: 'fixed', value: { default: false } },
 		pause_test: { mode: 'fixed', value: { default: false } },
+		pre_test_instructions: { value: { text: null } },
+		completion_message: { value: { text: null } },
 		platform_nomenclature: {
 			mode: 'default',
 			value: fillMissingNomenclatureKeys({})
@@ -83,8 +85,7 @@ describe('organizationSettingsSchema — platform_nomenclature', () => {
 
 	it('rejects mode values other than "default" / "custom"', () => {
 		const settings = validBaseSettings();
-		// @ts-expect-error - intentionally invalid
-		settings.platform_nomenclature = {
+		(settings as Record<string, unknown>).platform_nomenclature = {
 			mode: 'flexible',
 			value: fillMissingNomenclatureKeys({})
 		};
@@ -99,9 +100,9 @@ describe('organizationSettingsSchema — platform_nomenclature', () => {
 		expect(result.success).toBe(false);
 	});
 
-	it('pins version to literal 4', () => {
+	it('pins version to literal 5', () => {
 		const settings = validBaseSettings();
-		settings.version = 2 as 4; // wrong version
+		settings.version = 2 as 5; // wrong version
 		const result = organizationSettingsSchema.safeParse(settings);
 		expect(result.success).toBe(false);
 	});
@@ -114,7 +115,7 @@ describe('organizationSettingsSchema — platform_guide & analytics_link', () =>
 	});
 
 	it('accepts a resolved file_path URL and analytics URL', () => {
-		const settings = validBaseSettings();
+		const settings = validBaseSettings() as Record<string, unknown>;
 		settings.platform_guide = { value: { file_path: 'https://cdn.example.com/guide.pdf' } };
 		settings.analytics_link = { value: { url: 'https://lookerstudio.google.com/abc' } };
 		const result = organizationSettingsSchema.safeParse(settings);
@@ -129,6 +130,61 @@ describe('organizationSettingsSchema — platform_guide & analytics_link', () =>
 		const s2 = validBaseSettings() as Record<string, unknown>;
 		delete s2.analytics_link;
 		expect(organizationSettingsSchema.safeParse(s2).success).toBe(false);
+	});
+});
+
+describe('organizationSettingsSchema — pre_test_instructions & completion_message', () => {
+	it('accepts null text for both fields', () => {
+		const result = organizationSettingsSchema.safeParse(validBaseSettings());
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.pre_test_instructions.value.text).toBeNull();
+			expect(result.data.completion_message.value.text).toBeNull();
+		}
+	});
+
+	it('accepts an HTML string for pre_test_instructions', () => {
+		const settings = validBaseSettings() as Record<string, unknown>;
+		settings.pre_test_instructions = { value: { text: '<p>Read carefully</p>' } };
+		const result = organizationSettingsSchema.safeParse(settings);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.pre_test_instructions.value.text).toBe('<p>Read carefully</p>');
+		}
+	});
+
+	it('accepts an HTML string for completion_message', () => {
+		const settings = validBaseSettings() as Record<string, unknown>;
+		settings.completion_message = { value: { text: '<p>Thank you!</p>' } };
+		const result = organizationSettingsSchema.safeParse(settings);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.completion_message.value.text).toBe('<p>Thank you!</p>');
+		}
+	});
+
+	it('defaults text to null when value.text is omitted', () => {
+		const settings = validBaseSettings() as Record<string, unknown>;
+		settings.pre_test_instructions = { value: {} };
+		settings.completion_message = { value: {} };
+		const result = organizationSettingsSchema.safeParse(settings);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.pre_test_instructions.value.text).toBeNull();
+			expect(result.data.completion_message.value.text).toBeNull();
+		}
+	});
+
+	it('rejects payload missing pre_test_instructions', () => {
+		const settings = validBaseSettings() as Record<string, unknown>;
+		delete settings.pre_test_instructions;
+		expect(organizationSettingsSchema.safeParse(settings).success).toBe(false);
+	});
+
+	it('rejects payload missing completion_message', () => {
+		const settings = validBaseSettings() as Record<string, unknown>;
+		delete settings.completion_message;
+		expect(organizationSettingsSchema.safeParse(settings).success).toBe(false);
 	});
 });
 

--- a/src/routes/(admin)/organization/settings/schema.ts
+++ b/src/routes/(admin)/organization/settings/schema.ts
@@ -124,8 +124,20 @@ const analyticsLinkSchema = z.object({
 	})
 });
 
+const preTestInstructionsSchema = z.object({
+	value: z.object({
+		text: z.string().nullable().default(null)
+	})
+});
+
+const completionMessageSchema = z.object({
+	value: z.object({
+		text: z.string().nullable().default(null)
+	})
+});
+
 export const organizationSettingsSchema = z.object({
-	version: z.literal(4).default(4),
+	version: z.literal(5).default(5),
 	test_timings: testTimingsSchema,
 	questions_per_page: questionsPerPageSchema,
 	marking_scheme: markingSchemeSchema,
@@ -134,6 +146,8 @@ export const organizationSettingsSchema = z.object({
 	mark_for_review: markForReviewSchema,
 	omr_mode: omrModeSchema,
 	pause_test: pauseTestSchema,
+	pre_test_instructions: preTestInstructionsSchema,
+	completion_message: completionMessageSchema,
 	platform_nomenclature: platformNomenclatureSchema,
 	platform_guide: platformGuideSchema,
 	analytics_link: analyticsLinkSchema


### PR DESCRIPTION
Fixes #489 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization administrators can now configure pre-test instructions and completion messages in the organization settings page. These settings will automatically populate corresponding fields when creating new tests.

* **Tests**
  * Added comprehensive test coverage for test instruction settings, including configuration, normalization, and automatic population of test forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->