### PR TITLE
Fix: Display Tag-Type along with Tag In Question Edit

### DIFF
--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.server.ts
@@ -121,11 +121,13 @@ export const actions: Actions = {
 			});
 		}
 
-		const transformedFormData = {
+		const transformedFormData: Record<string, any> = {
 			...form.data,
 			state_ids: form.data.state_ids.map((s) => s.id),
 			tag_ids: form.data.tag_ids.map((t) => t.id)
 		};
+		// tag_type_ids is UI-only state for filtering the tag picker; never sent to the backend.
+		delete transformedFormData.tag_type_ids;
 
 		if (params.id === 'new') {
 			const response = await fetch(`${BACKEND_URL}/questions/`, {

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/+page.svelte
@@ -238,14 +238,21 @@
 	}
 
 	if (questionData?.tags?.length) {
-		$formData.tag_ids = questionData.tags.map((tag) => {
-			const tagName = tag.name;
-			const tagTypeName = tag.tag_type?.name;
-			return {
-				id: String((tag as { id: string | number }).id),
-				name: tagTypeName ? `${tagName} (${tagTypeName})` : tagName
-			};
+		$formData.tag_ids = questionData.tags.map((tag) => ({
+			id: String((tag as { id: string | number }).id),
+			name: tag.name
+		}));
+
+		const tagTypeMap = new Map<string, { id: string; name: string }>();
+		(questionData.tags as any[]).forEach((tag: any) => {
+			if (tag?.tag_type?.id) {
+				tagTypeMap.set(String(tag.tag_type.id), {
+					id: String(tag.tag_type.id),
+					name: tag.tag_type.name
+				});
+			}
 		});
+		$formData.tag_type_ids = Array.from(tagTypeMap.values());
 	}
 
 	if (questionData && !questionData.marking_scheme) {
@@ -325,7 +332,11 @@
 			: {}
 	);
 
-	let selectedTagTypes = $state<{ id: string; name: string }[]>([]);
+	let selectedTagTypes = $state<{ id: string; name: string }[]>($formData.tag_type_ids || []);
+
+	$effect(() => {
+		$formData.tag_type_ids = selectedTagTypes;
+	});
 	let openQuestionTypeDialog = $state(!questionData);
 	let showUnsavedDialog = $state(false);
 

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
@@ -2967,3 +2967,75 @@ describe('Single Question Page - Matrix Number Question Type', () => {
 		});
 	});
 });
+
+describe('Single Question Page - tag_type pre-population on edit', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('shows the tag type badge when editing a question whose tag belongs to a tag_type', () => {
+		const questionData = {
+			question_text: 'What is gravity?',
+			question_type: QuestionTypeEnum.SingleChoice,
+			options: [
+				{ id: 1, key: 'A', value: 'A force' },
+				{ id: 2, key: 'B', value: 'An energy' }
+			],
+			correct_answer: [1],
+			is_mandatory: false,
+			is_active: true,
+			tags: [{ id: 5, name: 'Physics', tag_type: { id: '10', name: 'Subject' } }]
+		};
+		render(SingleQuestionPage, { data: { ...baseData, questionData } as any });
+		expect(screen.getByText('Subject')).toBeInTheDocument();
+	});
+
+	it('shows multiple tag type badges when tags belong to different tag_types', () => {
+		const questionData = {
+			question_text: 'What is gravity?',
+			question_type: QuestionTypeEnum.SingleChoice,
+			options: [],
+			correct_answer: [],
+			is_mandatory: false,
+			is_active: true,
+			tags: [
+				{ id: 5, name: 'Physics', tag_type: { id: '10', name: 'Subject' } },
+				{ id: 6, name: 'Science', tag_type: { id: '20', name: 'Domain' } }
+			]
+		};
+		render(SingleQuestionPage, { data: { ...baseData, questionData } as any });
+		expect(screen.getByText('Subject')).toBeInTheDocument();
+		expect(screen.getByText('Domain')).toBeInTheDocument();
+	});
+
+	it('deduplicates the tag type badge when multiple tags share the same tag_type', () => {
+		const questionData = {
+			question_text: 'What is gravity?',
+			question_type: QuestionTypeEnum.SingleChoice,
+			options: [],
+			correct_answer: [],
+			is_mandatory: false,
+			is_active: true,
+			tags: [
+				{ id: 5, name: 'Physics', tag_type: { id: '10', name: 'Subject' } },
+				{ id: 6, name: 'Chemistry', tag_type: { id: '10', name: 'Subject' } }
+			]
+		};
+		render(SingleQuestionPage, { data: { ...baseData, questionData } as any });
+		expect(screen.getAllByText('Subject')).toHaveLength(1);
+	});
+
+	it('shows no tag type badge when tag has no tag_type', () => {
+		const questionData = {
+			question_text: 'What is gravity?',
+			question_type: QuestionTypeEnum.SingleChoice,
+			options: [],
+			correct_answer: [],
+			is_mandatory: false,
+			is_active: true,
+			tags: [{ id: 5, name: 'Physics' }]
+		};
+		render(SingleQuestionPage, { data: { ...baseData, questionData } as any });
+		expect(screen.queryByText('Subject')).not.toBeInTheDocument();
+	});
+});

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/schema.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/schema.ts
@@ -45,6 +45,7 @@ export const questionSchema = z.object({
 	district_ids: z.array(z.string()).default([]),
 	block_ids: z.array(z.string()).default([]),
 	tag_ids: z.array(z.object({ id: z.string(), name: z.string() })).default([]),
+	tag_type_ids: z.array(z.object({ id: z.string(), name: z.string() })).default([]),
 	is_active: z.boolean().default(true)
 });
 


### PR DESCRIPTION
Fixes #508 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tag types now pre-populate as badges when editing questions in the question bank.

* **Bug Fixes**
  * Improved tag type extraction and management to ensure proper separation and display in the question editor.

* **Tests**
  * Added test coverage for tag type badge rendering, deduplication, and edit-mode pre-population scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->