### PR TITLE
test cases for entity component

### DIFF
--- a/src/routes/(admin)/entity/[action]/[id]/EntityForm.svelte.test.ts
+++ b/src/routes/(admin)/entity/[action]/[id]/EntityForm.svelte.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { writable } from 'svelte/store';
+import EntityForm from './EntityForm.svelte';
+
+vi.mock('$app/paths', () => ({
+	resolve: vi.fn((path: string) => path)
+}));
+
+vi.mock('sveltekit-superforms/adapters', () => ({
+	zod4Client: vi.fn((schema) => schema)
+}));
+
+const superFormRef = vi.hoisted(() => ({
+	errors: null as ReturnType<typeof writable> | null
+}));
+
+vi.mock('sveltekit-superforms', () => ({
+	superForm: (initialData: Record<string, unknown>) => {
+		const data = (initialData as { data?: Record<string, unknown> })?.data ?? {};
+		const errorsStore = writable<Record<string, unknown>>({});
+		superFormRef.errors = errorsStore;
+		return {
+			form: writable(data),
+			errors: errorsStore,
+			enhance: () => () => {},
+			submit: vi.fn()
+		};
+	}
+}));
+
+function makeForm(data: { name: string; description?: string }) {
+	return { valid: true, data };
+}
+
+const createData = {
+	action: 'add' as const,
+	form: makeForm({ name: '', description: '' }),
+	entityType: null,
+	currentUser: { id: 1 }
+};
+
+const editData = {
+	action: 'edit' as const,
+	form: makeForm({ name: 'CLF', description: 'Community Level Federation' }),
+	entityType: { name: 'CLF', description: 'Community Level Federation' },
+	currentUser: { id: 1 }
+};
+
+describe('EntityForm', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		superFormRef.errors = null;
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Page title', () => {
+		it('shows "Create Entity" heading in add mode', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByText('Create Entity')).toBeInTheDocument();
+		});
+
+		it('shows "Edit Entity" heading in edit mode', () => {
+			render(EntityForm, { data: editData } as any);
+			expect(screen.getByText('Edit Entity')).toBeInTheDocument();
+		});
+
+		it('does not show "Edit Entity" heading in add mode', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.queryByText('Edit Entity')).not.toBeInTheDocument();
+		});
+
+		it('does not show "Create Entity" heading in edit mode', () => {
+			render(EntityForm, { data: editData } as any);
+			expect(screen.queryByText('Create Entity')).not.toBeInTheDocument();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Back link', () => {
+		it('renders a back link', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByRole('link', { name: /back to entities/i })).toBeInTheDocument();
+		});
+
+		it('back link points to /entity', () => {
+			render(EntityForm, { data: createData } as any);
+			const link = screen.getByRole('link', { name: /back to entities/i });
+			expect(link).toHaveAttribute('href', '/entity');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Form attributes', () => {
+		it('form has method POST', () => {
+			const { container } = render(EntityForm, { data: createData } as any);
+			const form = container.querySelector('form');
+			expect(form).toHaveAttribute('method', 'POST');
+		});
+
+		it('form has action ?/save', () => {
+			const { container } = render(EntityForm, { data: createData } as any);
+			const form = container.querySelector('form');
+			expect(form).toHaveAttribute('action', '?/save');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Name field', () => {
+		it('renders the Name label', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByText('Entity Name')).toBeInTheDocument();
+		});
+
+		it('renders the name input', () => {
+			const { container } = render(EntityForm, { data: createData } as any);
+			expect(container.querySelector('input[name="name"]')).toBeInTheDocument();
+		});
+
+		it('name input has correct placeholder in add mode', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByPlaceholderText('Name of this entity...')).toBeInTheDocument();
+		});
+
+		it('name input is empty in add mode', () => {
+			const { container } = render(EntityForm, { data: createData } as any);
+			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
+			expect(input.value).toBe('');
+		});
+
+		it('name input is pre-filled in edit mode', () => {
+			const { container } = render(EntityForm, { data: editData } as any);
+			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
+			expect(input.value).toBe('CLF');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Description field', () => {
+		it('renders the Description label', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByText('Description')).toBeInTheDocument();
+		});
+
+		it('renders the description textarea', () => {
+			const { container } = render(EntityForm, { data: createData } as any);
+			expect(container.querySelector('textarea[name="description"]')).toBeInTheDocument();
+		});
+
+		it('description textarea has correct placeholder', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(
+				screen.getByPlaceholderText('Brief description of this entity...')
+			).toBeInTheDocument();
+		});
+
+		it('description textarea is empty in add mode', () => {
+			const { container } = render(EntityForm, { data: createData } as any);
+			const textarea = container.querySelector(
+				'textarea[name="description"]'
+			) as HTMLTextAreaElement;
+			expect(textarea.value).toBe('');
+		});
+
+		it('description textarea is pre-filled in edit mode', () => {
+			const { container } = render(EntityForm, { data: editData } as any);
+			const textarea = container.querySelector(
+				'textarea[name="description"]'
+			) as HTMLTextAreaElement;
+			expect(textarea.value).toBe('Community Level Federation');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Save button', () => {
+		it('renders the Save button with label "Save Entity"', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByRole('button', { name: /save entity/i })).toBeInTheDocument();
+		});
+
+		it('Save button is DISABLED when name is empty', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByRole('button', { name: /save entity/i })).toBeDisabled();
+		});
+
+		it('Save button is DISABLED when name is only whitespace', () => {
+			render(EntityForm, {
+				data: { ...createData, form: makeForm({ name: '   ' }) }
+			} as any);
+			expect(screen.getByRole('button', { name: /save entity/i })).toBeDisabled();
+		});
+
+		it('Save button is ENABLED when name has a value in edit mode', () => {
+			render(EntityForm, { data: editData } as any);
+			expect(screen.getByRole('button', { name: /save entity/i })).toBeEnabled();
+		});
+
+		it('Save button becomes ENABLED after the user types a name', async () => {
+			const { container } = render(EntityForm, { data: createData } as any);
+			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
+
+			await fireEvent.input(input, { target: { value: 'New Entity' } });
+			await tick();
+
+			expect(screen.getByRole('button', { name: /save entity/i })).toBeEnabled();
+		});
+
+		it('Save button becomes DISABLED again when name is cleared', async () => {
+			const { container } = render(EntityForm, { data: editData } as any);
+			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
+
+			await fireEvent.input(input, { target: { value: '' } });
+			await tick();
+
+			expect(screen.getByRole('button', { name: /save entity/i })).toBeDisabled();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Validation error display', () => {
+		it('does NOT show a name error message when there are no errors', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.queryByText('Entity name is required')).not.toBeInTheDocument();
+		});
+
+		it('shows the name error message when $errors.name is set', async () => {
+			render(EntityForm, { data: createData } as any);
+
+			superFormRef.errors!.set({ name: ['Entity name is required'] });
+			await tick();
+
+			expect(screen.getByText('Entity name is required')).toBeInTheDocument();
+		});
+
+		it('clears the name error message when $errors.name is removed', async () => {
+			render(EntityForm, { data: createData } as any);
+
+			superFormRef.errors!.set({ name: ['Entity name is required'] });
+			await tick();
+			superFormRef.errors!.set({});
+			await tick();
+
+			expect(screen.queryByText('Entity name is required')).not.toBeInTheDocument();
+		});
+	});
+});

--- a/src/routes/(admin)/entity/[action]/[id]/EntityForm.svelte.test.ts
+++ b/src/routes/(admin)/entity/[action]/[id]/EntityForm.svelte.test.ts
@@ -37,16 +37,12 @@ function makeForm(data: { name: string; description?: string }) {
 
 const createData = {
 	action: 'add' as const,
-	form: makeForm({ name: '', description: '' }),
-	entityType: null,
-	currentUser: { id: 1 }
+	form: makeForm({ name: '', description: '' })
 };
 
 const editData = {
 	action: 'edit' as const,
-	form: makeForm({ name: 'CLF', description: 'Community Level Federation' }),
-	entityType: { name: 'CLF', description: 'Community Level Federation' },
-	currentUser: { id: 1 }
+	form: makeForm({ name: 'CLF', description: 'Community Level Federation' })
 };
 
 describe('EntityForm', () => {

--- a/src/routes/(admin)/entity/[action]/[id]/EntityRecordList.svelte.test.ts
+++ b/src/routes/(admin)/entity/[action]/[id]/EntityRecordList.svelte.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { page } from '$app/state';
+import { goto } from '$app/navigation';
+import { canCreate, canUpdate, canDelete } from '$lib/utils/permissions.js';
+import EntityRecordList from './EntityRecordList.svelte';
+
+vi.mock('$app/state', () => ({
+	page: { url: new URL('http://localhost/entity/view/42') }
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(),
+	invalidateAll: vi.fn()
+}));
+
+vi.mock('$app/forms', () => ({
+	enhance: vi.fn(() => () => {})
+}));
+
+vi.mock('$app/paths', () => ({
+	resolve: vi.fn((path: string) => path)
+}));
+
+vi.mock('$lib/constants', () => ({
+	DEFAULT_PAGE_SIZE: 25
+}));
+
+vi.mock('$lib/utils/permissions.js', () => ({
+	canCreate: vi.fn(() => false),
+	canUpdate: vi.fn(() => false),
+	canDelete: vi.fn(() => false)
+}));
+
+vi.mock('$lib/components/data-table/BatchActionsToolbar.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+vi.mock('$lib/components/DeleteDialog.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+vi.mock('$lib/components/data-table', () => ({
+	DataTable: vi.fn((_, props: any) => void props?.columns)
+}));
+
+const colRef = vi.hoisted(() => ({
+	handleSort: null as ((col: string) => void) | null,
+	enableSelection: undefined as boolean | undefined,
+	permissions: undefined as { canEdit?: boolean; canDelete?: boolean } | undefined
+}));
+
+vi.mock('./entity-columns', () => ({
+	createEntityColumns: vi.fn((...args: unknown[]) => {
+		colRef.handleSort = args[3] as (col: string) => void;
+		colRef.enableSelection = args[4] as boolean;
+		colRef.permissions = args[5] as { canEdit?: boolean; canDelete?: boolean };
+		return [];
+	})
+}));
+
+const sampleItems = [
+	{ id: 1, name: 'Kokan SHG', modified_date: '2026-06-01', state: null, district: null, block: null },
+	{ id: 2, name: 'Pune SHG', modified_date: '2026-06-02', state: null, district: null, block: null }
+];
+
+function makeData(
+	items: any[] = [],
+	params: Partial<{ search: string; isActive: string; sortBy: string; sortOrder: string }> = {},
+	entityType: { name: string } | null = { name: 'SHG' },
+	entityTypeId = '42'
+) {
+	return {
+		entities: { items, total: items.length, pages: items.length > 0 ? 1 : 0 },
+		totalPages: items.length > 0 ? 1 : 0,
+		params: {
+			page: 1,
+			size: 25,
+			search: '',
+			sortBy: '',
+			sortOrder: 'asc',
+			isActive: '',
+			...params
+		},
+		entityType,
+		entityTypeId,
+		user: { id: 1, permissions: [] }
+	};
+}
+
+describe('EntityRecordList', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(page as any).url = new URL('http://localhost/entity/view/42');
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Page title', () => {
+		it('shows the entity type name as the title', () => {
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(screen.getByText('SHG')).toBeInTheDocument();
+		});
+
+		it('falls back to "Entity" when entityType is null', () => {
+			render(EntityRecordList, { data: makeData(sampleItems, {}, null) } as any);
+			expect(screen.getByText('Entity')).toBeInTheDocument();
+		});
+
+		it('uses the entity type name from data', () => {
+			render(EntityRecordList, { data: makeData(sampleItems, {}, { name: 'CLF' }) } as any);
+			expect(screen.getByText('CLF')).toBeInTheDocument();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Add Record button', () => {
+		it('shows the add button when user has create permission', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(screen.getByRole('link', { name: /add shg record/i })).toBeInTheDocument();
+		});
+
+		it('does NOT show the add button when user lacks create permission', () => {
+			vi.mocked(canCreate).mockReturnValue(false);
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(screen.queryByRole('link', { name: /add.*record/i })).not.toBeInTheDocument();
+		});
+
+		it('add button links to /entity/view/{entityTypeId}/add/new', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(screen.getByRole('link', { name: /add shg record/i })).toHaveAttribute(
+				'href',
+				'/entity/view/42/add/new'
+			);
+		});
+
+		it('add button label uses the entity type name', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			render(EntityRecordList, {
+				data: makeData(sampleItems, {}, { name: 'CLF' }, '99')
+			} as any);
+			expect(screen.getByRole('link', { name: /add clf record/i })).toBeInTheDocument();
+		});
+
+		it('add button uses the correct entityTypeId in the href', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			render(EntityRecordList, {
+				data: makeData(sampleItems, {}, { name: 'SHG' }, '99')
+			} as any);
+			expect(screen.getByRole('link', { name: /add shg record/i })).toHaveAttribute(
+				'href',
+				'/entity/view/99/add/new'
+			);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Search input', () => {
+		it('renders the search input with placeholder "Search records..."', () => {
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(screen.getByPlaceholderText('Search records...')).toBeInTheDocument();
+		});
+
+		it('reflects the current search value from params', () => {
+			render(EntityRecordList, { data: makeData(sampleItems, { search: 'Kokan' }) } as any);
+			expect(screen.getByPlaceholderText('Search records...')).toHaveValue('Kokan');
+		});
+
+		it('shows an empty value when no search is active', () => {
+			render(EntityRecordList, { data: makeData(sampleItems, { search: '' }) } as any);
+			expect(screen.getByPlaceholderText('Search records...')).toHaveValue('');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Status filter', () => {
+		it('renders "Status" button when no filter is active', () => {
+			render(EntityRecordList, { data: makeData(sampleItems, { isActive: '' }) } as any);
+			expect(screen.getByRole('button', { name: /status/i })).toBeInTheDocument();
+		});
+
+		it('renders "Active" label when isActive is "true"', () => {
+			render(EntityRecordList, { data: makeData(sampleItems, { isActive: 'true' }) } as any);
+			expect(screen.getByRole('button', { name: /active/i })).toBeInTheDocument();
+		});
+
+		it('renders "Inactive" label when isActive is "false"', () => {
+			render(EntityRecordList, { data: makeData(sampleItems, { isActive: 'false' }) } as any);
+			expect(screen.getByRole('button', { name: /inactive/i })).toBeInTheDocument();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Batch delete form', () => {
+		it('renders the hidden batch delete form', () => {
+			const { container } = render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(container.querySelector('#batch-delete-records-form')).toBeInTheDocument();
+		});
+
+		it('form has method POST', () => {
+			const { container } = render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(container.querySelector('#batch-delete-records-form')).toHaveAttribute(
+				'method',
+				'POST'
+			);
+		});
+
+		it('form has action ?/batchDeleteRecords', () => {
+			const { container } = render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(container.querySelector('#batch-delete-records-form')).toHaveAttribute(
+				'action',
+				'?/batchDeleteRecords'
+			);
+		});
+
+		it('form contains a hidden input for entityRecordIds', () => {
+			const { container } = render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(
+				container.querySelector('input[name="entityRecordIds"]')
+			).toBeInTheDocument();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('enableSelection passed to columns', () => {
+		it('passes enableSelection=true when items exist', () => {
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(colRef.enableSelection).toBe(true);
+		});
+
+		it('passes enableSelection=false when no items', () => {
+			render(EntityRecordList, { data: makeData([]) } as any);
+			expect(colRef.enableSelection).toBe(false);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Permissions passed to columns', () => {
+		it('passes canEdit=true when user has update permission', () => {
+			vi.mocked(canUpdate).mockReturnValue(true);
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(colRef.permissions?.canEdit).toBe(true);
+		});
+
+		it('passes canEdit=false when user lacks update permission', () => {
+			vi.mocked(canUpdate).mockReturnValue(false);
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(colRef.permissions?.canEdit).toBe(false);
+		});
+
+		it('passes canDelete=true when user has delete permission', () => {
+			vi.mocked(canDelete).mockReturnValue(true);
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(colRef.permissions?.canDelete).toBe(true);
+		});
+
+		it('passes canDelete=false when user lacks delete permission', () => {
+			vi.mocked(canDelete).mockReturnValue(false);
+			render(EntityRecordList, { data: makeData(sampleItems) } as any);
+			expect(colRef.permissions?.canDelete).toBe(false);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Sorting (handleSort)', () => {
+		async function renderAndCaptureSort(sortByParam = '', sortOrderParam = 'asc') {
+			colRef.handleSort = null;
+			render(EntityRecordList, {
+				data: makeData(sampleItems, { sortBy: sortByParam, sortOrder: sortOrderParam })
+			} as any);
+			await waitFor(() => {
+				if (!colRef.handleSort) throw new Error('handleSort not captured');
+			});
+		}
+
+		function parsedGotoUrl(): URLSearchParams {
+			const [calledPath] = vi.mocked(goto).mock.calls[0] as [string, unknown];
+			return new URL('http://localhost' + calledPath).searchParams;
+		}
+
+		it('sets sortBy to the clicked column', async () => {
+			await renderAndCaptureSort();
+			colRef.handleSort!('name');
+			expect(parsedGotoUrl().get('sortBy')).toBe('name');
+		});
+
+		it('defaults sortOrder to asc when sorting a new column', async () => {
+			await renderAndCaptureSort('', 'asc');
+			colRef.handleSort!('name');
+			expect(parsedGotoUrl().get('sortOrder')).toBe('asc');
+		});
+
+		it('toggles sortOrder to desc when clicking the already-sorted-asc column', async () => {
+			await renderAndCaptureSort('name', 'asc');
+			colRef.handleSort!('name');
+			expect(parsedGotoUrl().get('sortOrder')).toBe('desc');
+		});
+
+		it('toggles sortOrder back to asc when clicking the already-sorted-desc column', async () => {
+			await renderAndCaptureSort('name', 'desc');
+			colRef.handleSort!('name');
+			expect(parsedGotoUrl().get('sortOrder')).toBe('asc');
+		});
+
+		it('resets page to 1 on every sort', async () => {
+			await renderAndCaptureSort();
+			colRef.handleSort!('name');
+			expect(parsedGotoUrl().get('page')).toBe('1');
+		});
+
+		it('calls goto with replaceState: false', async () => {
+			await renderAndCaptureSort();
+			colRef.handleSort!('name');
+			const [, opts] = vi.mocked(goto).mock.calls[0] as [string, { replaceState: boolean }];
+			expect(opts.replaceState).toBe(false);
+		});
+
+		it('asc → desc does NOT toggle when a different column is clicked', async () => {
+			await renderAndCaptureSort('name', 'asc');
+			colRef.handleSort!('modified_date');
+			expect(parsedGotoUrl().get('sortOrder')).toBe('asc');
+		});
+	});
+});

--- a/src/routes/(admin)/entity/[action]/[id]/[entityAction]/[entityId]/EntityRecordForm.svelte.test.ts
+++ b/src/routes/(admin)/entity/[action]/[id]/[entityAction]/[entityId]/EntityRecordForm.svelte.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { writable } from 'svelte/store';
+import EntityRecordForm from './EntityRecordForm.svelte';
+
+vi.mock('$app/paths', () => ({
+	resolve: vi.fn((path: string) => path)
+}));
+
+vi.mock('sveltekit-superforms/adapters', () => ({
+	zod4Client: vi.fn((schema) => schema)
+}));
+
+vi.mock('$lib/components/StateSelection.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+vi.mock('$lib/components/DistrictSelection.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+vi.mock('$lib/components/BlockSelection.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+const superFormRef = vi.hoisted(() => ({
+	errors: null as ReturnType<typeof writable> | null
+}));
+
+vi.mock('sveltekit-superforms', () => ({
+	superForm: (initialData: Record<string, unknown>) => {
+		const data = (initialData as { data?: Record<string, unknown> })?.data ?? {};
+		const errorsStore = writable<Record<string, unknown>>({});
+		superFormRef.errors = errorsStore;
+		return {
+			form: writable(data),
+			errors: errorsStore,
+			enhance: () => () => {},
+			submit: vi.fn()
+		};
+	}
+}));
+
+function makeForm(data: {
+	name?: string;
+	description?: string | null;
+	state_id?: number | null;
+	district_id?: number | null;
+	block_id?: number | null;
+}) {
+	return { valid: true, data: { name: '', description: '', state_id: null, district_id: null, block_id: null, ...data } };
+}
+
+const createData = {
+	entityAction: 'add' as const,
+	entityTypeId: '42',
+	form: makeForm({ name: '', description: '' }),
+	entity: null,
+	entityType: { id: 42, name: 'SHG' }
+};
+
+const editData = {
+	entityAction: 'edit' as const,
+	entityTypeId: '42',
+	form: makeForm({ name: 'Kokan SHG', description: 'A group in Kokan' }),
+	entity: {
+		name: 'Kokan SHG',
+		description: 'A group in Kokan',
+		state: { id: 1, name: 'Maharashtra' },
+		district: { id: 10, name: 'Ratnagiri' },
+		block: { id: 100, name: 'Lanja' }
+	},
+	entityType: { id: 42, name: 'SHG' }
+};
+
+describe('EntityRecordForm', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		superFormRef.errors = null;
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Page title', () => {
+		it('shows "Create SHG Record" in add mode', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByText('Create SHG Record')).toBeInTheDocument();
+		});
+
+		it('shows "Edit SHG Record" in edit mode', () => {
+			render(EntityRecordForm, { data: editData } as any);
+			expect(screen.getByText('Edit SHG Record')).toBeInTheDocument();
+		});
+
+		it('falls back to "Entity" in the title when entityType is null', () => {
+			render(EntityRecordForm, {
+				data: { ...createData, entityType: null }
+			} as any);
+			expect(screen.getByText('Create Entity Record')).toBeInTheDocument();
+		});
+
+		it('does not show "Edit" title in add mode', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.queryByText(/edit.*record/i)).not.toBeInTheDocument();
+		});
+
+		it('does not show "Create" title in edit mode', () => {
+			render(EntityRecordForm, { data: editData } as any);
+			expect(screen.queryByText(/create.*record/i)).not.toBeInTheDocument();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Back link', () => {
+		it('renders a back link with aria-label "Back to records"', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByRole('link', { name: /back to records/i })).toBeInTheDocument();
+		});
+
+		it('back link points to /entity/view/{entityTypeId}', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByRole('link', { name: /back to records/i })).toHaveAttribute(
+				'href',
+				'/entity/view/42'
+			);
+		});
+
+		it('back link uses the correct entityTypeId', () => {
+			render(EntityRecordForm, {
+				data: { ...createData, entityTypeId: '99' }
+			} as any);
+			expect(screen.getByRole('link', { name: /back to records/i })).toHaveAttribute(
+				'href',
+				'/entity/view/99'
+			);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Form attributes', () => {
+		it('form has method POST', () => {
+			const { container } = render(EntityRecordForm, { data: createData } as any);
+			expect(container.querySelector('form')).toHaveAttribute('method', 'POST');
+		});
+
+		it('form has action ?/save', () => {
+			const { container } = render(EntityRecordForm, { data: createData } as any);
+			expect(container.querySelector('form')).toHaveAttribute('action', '?/save');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Name field', () => {
+		it('renders the "Name" section heading', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByText('Name')).toBeInTheDocument();
+		});
+
+		it('renders the name input', () => {
+			const { container } = render(EntityRecordForm, { data: createData } as any);
+			expect(container.querySelector('input[name="name"]')).toBeInTheDocument();
+		});
+
+		it('name input has correct placeholder', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByPlaceholderText('Name of this entity...')).toBeInTheDocument();
+		});
+
+		it('name input is empty in add mode', () => {
+			const { container } = render(EntityRecordForm, { data: createData } as any);
+			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
+			expect(input.value).toBe('');
+		});
+
+		it('name input is pre-filled in edit mode', () => {
+			const { container } = render(EntityRecordForm, { data: editData } as any);
+			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
+			expect(input.value).toBe('Kokan SHG');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Description field', () => {
+		it('renders the "Description" section heading', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByText('Description')).toBeInTheDocument();
+		});
+
+		it('renders the description textarea', () => {
+			const { container } = render(EntityRecordForm, { data: createData } as any);
+			expect(container.querySelector('textarea[name="description"]')).toBeInTheDocument();
+		});
+
+		it('description textarea has correct placeholder', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(
+				screen.getByPlaceholderText('Brief description of this entity...')
+			).toBeInTheDocument();
+		});
+
+		it('description textarea is empty in add mode', () => {
+			const { container } = render(EntityRecordForm, { data: createData } as any);
+			const textarea = container.querySelector(
+				'textarea[name="description"]'
+			) as HTMLTextAreaElement;
+			expect(textarea.value).toBe('');
+		});
+
+		it('description textarea is pre-filled in edit mode', () => {
+			const { container } = render(EntityRecordForm, { data: editData } as any);
+			const textarea = container.querySelector(
+				'textarea[name="description"]'
+			) as HTMLTextAreaElement;
+			expect(textarea.value).toBe('A group in Kokan');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Location section headings', () => {
+		it('renders "State" section heading', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByText('State')).toBeInTheDocument();
+		});
+
+		it('renders "District" section heading', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByText('District')).toBeInTheDocument();
+		});
+
+		it('renders "Block" section heading', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByText('Block')).toBeInTheDocument();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Save button', () => {
+		it('renders a Save button', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+		});
+
+		it('Save button is DISABLED when name is empty', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+		});
+
+		it('Save button is DISABLED when name is only whitespace', () => {
+			render(EntityRecordForm, {
+				data: { ...createData, form: makeForm({ name: '   ' }) }
+			} as any);
+			expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+		});
+
+		it('Save button is ENABLED when name has a value', () => {
+			render(EntityRecordForm, { data: editData } as any);
+			expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+		});
+
+		it('Save button becomes ENABLED after typing a name', async () => {
+			const { container } = render(EntityRecordForm, { data: createData } as any);
+			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
+
+			await fireEvent.input(input, { target: { value: 'New Record' } });
+			await tick();
+
+			expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+		});
+
+		it('Save button becomes DISABLED again when name is cleared', async () => {
+			const { container } = render(EntityRecordForm, { data: editData } as any);
+			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
+
+			await fireEvent.input(input, { target: { value: '' } });
+			await tick();
+
+			expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Validation error display', () => {
+		it('does NOT show a name error by default', () => {
+			render(EntityRecordForm, { data: createData } as any);
+			expect(screen.queryByText('Record name is required')).not.toBeInTheDocument();
+		});
+
+		it('shows name error when $errors.name is set', async () => {
+			render(EntityRecordForm, { data: createData } as any);
+			superFormRef.errors!.set({ name: ['Record name is required'] });
+			await tick();
+			expect(screen.getByText('Record name is required')).toBeInTheDocument();
+		});
+
+		it('clears name error when $errors.name is removed', async () => {
+			render(EntityRecordForm, { data: createData } as any);
+			superFormRef.errors!.set({ name: ['Record name is required'] });
+			await tick();
+			superFormRef.errors!.set({});
+			await tick();
+			expect(screen.queryByText('Record name is required')).not.toBeInTheDocument();
+		});
+
+		it('shows state_id error when $errors.state_id is set', async () => {
+			render(EntityRecordForm, { data: createData } as any);
+			superFormRef.errors!.set({ state_id: ['State is required'] });
+			await tick();
+			expect(screen.getByText('State is required')).toBeInTheDocument();
+		});
+
+		it('shows district_id error when $errors.district_id is set', async () => {
+			render(EntityRecordForm, { data: createData } as any);
+			superFormRef.errors!.set({ district_id: ['District is required'] });
+			await tick();
+			expect(screen.getByText('District is required')).toBeInTheDocument();
+		});
+
+		it('shows block_id error when $errors.block_id is set', async () => {
+			render(EntityRecordForm, { data: createData } as any);
+			superFormRef.errors!.set({ block_id: ['Block is required'] });
+			await tick();
+			expect(screen.getByText('Block is required')).toBeInTheDocument();
+		});
+	});
+});

--- a/src/routes/(admin)/entity/page.server.test.ts
+++ b/src/routes/(admin)/entity/page.server.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { load, actions } from './+page.server';
+import { requirePermission, PERMISSIONS } from '$lib/utils/permissions.js';
+import { setFlash } from 'sveltekit-flash-message/server';
+import { fail } from '@sveltejs/kit';
+
+vi.mock('$env/static/private', () => ({
+	BACKEND_URL: 'http://localhost:8000'
+}));
+
+vi.mock('$lib/constants.js', () => ({
+	DEFAULT_PAGE_SIZE: 25
+}));
+
+vi.mock('$lib/server/auth', () => ({
+	getSessionTokenCookie: vi.fn(() => 'mock-token'),
+	requireLogin: vi.fn(() => ({ id: 1, permissions: ['read_entity', 'delete_entity'] }))
+}));
+
+vi.mock('$lib/utils/permissions.js', () => ({
+	requirePermission: vi.fn(),
+	PERMISSIONS: {
+		READ_ENTITY: 'read_entity',
+		DELETE_ENTITY: 'delete_entity'
+	}
+}));
+
+vi.mock('@sveltejs/kit', () => ({
+	fail: vi.fn((status: number) => ({ status, type: 'failure' }))
+}));
+
+vi.mock('sveltekit-flash-message/server', () => ({
+	setFlash: vi.fn()
+}));
+
+const mockCookies = {
+	get: vi.fn(),
+	getAll: vi.fn(),
+	set: vi.fn(),
+	delete: vi.fn(),
+	serialize: vi.fn()
+};
+
+function makeUrl(path: string, params = '') {
+	return new URL(`http://localhost${path}${params ? '?' + params : ''}`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Entity Listing — load()', () => {
+	const mockFetch = vi.fn();
+
+	beforeEach(() => {
+		global.fetch = mockFetch;
+		mockFetch.mockClear();
+		vi.clearAllMocks();
+	});
+
+	function mockSuccess(data = { items: [{ id: 1, name: 'CLF' }], total: 1, pages: 2 }) {
+		mockFetch.mockResolvedValueOnce({ ok: true, json: async () => data });
+	}
+
+	function mockFailure(statusText = 'Internal Server Error') {
+		mockFetch.mockResolvedValueOnce({ ok: false, statusText });
+	}
+
+	// ── Permissions ───────────────────────────────────────────────────────────
+	describe('Permissions', () => {
+		it('requires READ_ENTITY permission', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity') } as any);
+			expect(requirePermission).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 1 }),
+				PERMISSIONS.READ_ENTITY
+			);
+		});
+	});
+
+	// ── API call — query parameters ───────────────────────────────────────────
+	describe('API call — query parameters', () => {
+		it('calls the /entitytype/ endpoint', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity') } as any);
+			expect(mockFetch.mock.calls[0][0]).toContain('/entitytype/');
+		});
+
+		it('sends Bearer token in Authorization header', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity') } as any);
+			expect(mockFetch).toHaveBeenCalledWith(
+				expect.stringContaining('/entitytype/'),
+				expect.objectContaining({ headers: { Authorization: 'Bearer mock-token' } })
+			);
+		});
+
+		it('includes default page=1 and size=25', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity') } as any);
+			const url = mockFetch.mock.calls[0][0] as string;
+			expect(url).toContain('page=1');
+			expect(url).toContain('size=25');
+		});
+
+		it('forwards custom page and size', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity', 'page=3&size=10') } as any);
+			const url = mockFetch.mock.calls[0][0] as string;
+			expect(url).toContain('page=3');
+			expect(url).toContain('size=10');
+		});
+
+		it('maps search param to name in the API URL', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity', 'search=CLF') } as any);
+			const url = mockFetch.mock.calls[0][0] as string;
+			expect(url).toContain('name=CLF');
+			expect(url).not.toContain('search=CLF');
+		});
+
+		it('maps sortBy to sort_by and sortOrder to sort_order', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity', 'sortBy=name&sortOrder=desc') } as any);
+			const url = mockFetch.mock.calls[0][0] as string;
+			expect(url).toContain('sort_by=name');
+			expect(url).toContain('sort_order=desc');
+		});
+
+		it('omits sort_by when sortBy is not provided', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity') } as any);
+			expect(mockFetch.mock.calls[0][0]).not.toContain('sort_by');
+		});
+
+		it('includes is_active=true when isActive=true', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity', 'isActive=true') } as any);
+			expect(mockFetch.mock.calls[0][0]).toContain('is_active=true');
+		});
+
+		it('includes is_active=false when isActive=false', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity', 'isActive=false') } as any);
+			expect(mockFetch.mock.calls[0][0]).toContain('is_active=false');
+		});
+
+		it('omits is_active when isActive param is not set', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity') } as any);
+			expect(mockFetch.mock.calls[0][0]).not.toContain('is_active');
+		});
+
+		it('normalises isActive casing — "TRUE" is treated as "true"', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity', 'isActive=TRUE') } as any);
+			expect(mockFetch.mock.calls[0][0]).toContain('is_active=true');
+		});
+
+		it('omits is_active when isActive is an unrecognised value (e.g. "yes")', async () => {
+			mockSuccess();
+			await load({ url: makeUrl('/entity', 'isActive=yes') } as any);
+			expect(mockFetch.mock.calls[0][0]).not.toContain('is_active');
+		});
+	});
+
+	// ── Return value — success ─────────────────────────────────────────────────
+	describe('Return value — success', () => {
+		it('returns entities from the API response', async () => {
+			const mockData = { items: [{ id: 1, name: 'CLF' }], total: 1, pages: 3 };
+			mockSuccess(mockData);
+			const result = (await load({ url: makeUrl('/entity') } as any)) as any;
+			expect(result.entities).toEqual(mockData);
+		});
+
+		it('returns totalPages from the API response pages field', async () => {
+			mockSuccess({ items: [], total: 0, pages: 5 });
+			const result = (await load({ url: makeUrl('/entity') } as any)) as any;
+			expect(result.totalPages).toBe(5);
+		});
+
+		it('returns correct params object reflecting the request URL', async () => {
+			mockSuccess();
+			const result = (await load({
+				url: makeUrl('/entity', 'page=2&size=10&search=test&sortBy=name&sortOrder=desc&isActive=true')
+			} as any)) as any;
+			expect(result.params).toEqual({
+				page: 2,
+				size: 10,
+				search: 'test',
+				sortBy: 'name',
+				sortOrder: 'desc',
+				isActive: 'true'
+			});
+		});
+
+		it('returns default params when no URL params are provided', async () => {
+			mockSuccess();
+			const result = (await load({ url: makeUrl('/entity') } as any)) as any;
+			expect(result.params).toEqual({
+				page: 1,
+				size: 25,
+				search: '',
+				sortBy: '',
+				sortOrder: 'asc',
+				isActive: ''
+			});
+		});
+	});
+
+	// ── Return value — API failure ─────────────────────────────────────────────
+	describe('Return value — API failure', () => {
+		it('returns entities: null when fetch fails', async () => {
+			mockFailure('Server Error');
+			const result = (await load({ url: makeUrl('/entity') } as any)) as any;
+			expect(result.entities).toBeNull();
+		});
+
+		it('still returns params on API failure', async () => {
+			mockFailure();
+			const result = (await load({
+				url: makeUrl('/entity', 'page=2&size=10')
+			} as any)) as any;
+			expect(result.params.page).toBe(2);
+			expect(result.params.size).toBe(10);
+		});
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Entity Listing — batchDelete action', () => {
+	const mockFetch = vi.fn();
+
+	beforeEach(() => {
+		global.fetch = mockFetch;
+		mockFetch.mockClear();
+		vi.clearAllMocks();
+	});
+
+	function makeRequest(entityIds: number[]) {
+		return {
+			formData: vi.fn().mockResolvedValue({
+				get: vi.fn((key: string) => (key === 'entityIds' ? JSON.stringify(entityIds) : null))
+			})
+		};
+	}
+
+	function makeEvent(entityIds: number[]) {
+		return { request: makeRequest(entityIds), cookies: mockCookies };
+	}
+
+	function mockBackendSuccess(successCount: number, failureList: number[] | null = null) {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				delete_success_count: successCount,
+				delete_failure_list: failureList
+			})
+		});
+	}
+
+	function mockBackendError(detail = 'Cannot delete') {
+		mockFetch.mockResolvedValueOnce({
+			ok: false,
+			statusText: 'Internal Server Error',
+			json: async () => ({ detail })
+		});
+	}
+
+	// ── Permissions ───────────────────────────────────────────────────────────
+	describe('Permissions', () => {
+		it('requires DELETE_ENTITY permission', async () => {
+			mockBackendSuccess(1);
+			await actions.batchDelete(makeEvent([1]) as any);
+			expect(requirePermission).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 1 }),
+				PERMISSIONS.DELETE_ENTITY
+			);
+		});
+	});
+
+	// ── API call ──────────────────────────────────────────────────────────────
+	describe('API call', () => {
+		it('calls DELETE /entitytype/ endpoint', async () => {
+			mockBackendSuccess(2);
+			await actions.batchDelete(makeEvent([1, 2]) as any);
+			expect(mockFetch).toHaveBeenCalledWith(
+				'http://localhost:8000/entitytype/',
+				expect.objectContaining({ method: 'DELETE' })
+			);
+		});
+
+		it('sends entityIds from formData as the request body', async () => {
+			mockBackendSuccess(2);
+			await actions.batchDelete(makeEvent([1, 2]) as any);
+			const [, opts] = mockFetch.mock.calls[0];
+			expect(opts.body).toBe(JSON.stringify([1, 2]));
+		});
+
+		it('sends Bearer token in Authorization header', async () => {
+			mockBackendSuccess(1);
+			await actions.batchDelete(makeEvent([1]) as any);
+			const [, opts] = mockFetch.mock.calls[0];
+			expect(opts.headers.Authorization).toBe('Bearer mock-token');
+		});
+
+		it('sends Content-Type: application/json header', async () => {
+			mockBackendSuccess(1);
+			await actions.batchDelete(makeEvent([1]) as any);
+			const [, opts] = mockFetch.mock.calls[0];
+			expect(opts.headers['Content-Type']).toBe('application/json');
+		});
+	});
+
+	// ── Success response ──────────────────────────────────────────────────────
+	describe('Success response', () => {
+		it('returns { success: true } when all deletions succeed', async () => {
+			mockBackendSuccess(3);
+			const result = await actions.batchDelete(makeEvent([1, 2, 3]) as any);
+			expect(result).toEqual({ success: true });
+		});
+
+		it('sets a success flash when delete_failure_list is null', async () => {
+			mockBackendSuccess(2, null);
+			await actions.batchDelete(makeEvent([1, 2]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'success' }),
+				mockCookies
+			);
+		});
+
+		it('sets a success flash when delete_failure_list is an empty array', async () => {
+			mockBackendSuccess(2, []);
+			await actions.batchDelete(makeEvent([1, 2]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'success' }),
+				mockCookies
+			);
+		});
+
+		it('flash message includes the successful deletion count', async () => {
+			mockBackendSuccess(4, null);
+			await actions.batchDelete(makeEvent([1, 2, 3, 4]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ message: expect.stringContaining('4') }),
+				mockCookies
+			);
+		});
+
+		it('sets an error flash when delete_failure_list is non-empty', async () => {
+			mockBackendSuccess(2, [3]);
+			await actions.batchDelete(makeEvent([1, 2, 3]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'error' }),
+				mockCookies
+			);
+		});
+
+		it('flash message includes the failure count when some deletions fail', async () => {
+			mockBackendSuccess(1, [2, 3]);
+			await actions.batchDelete(makeEvent([1, 2, 3]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ message: expect.stringContaining('2') }),
+				mockCookies
+			);
+		});
+	});
+
+	// ── Error handling — backend returns non-ok ───────────────────────────────
+	describe('Error handling — backend non-ok response', () => {
+		it('returns fail(500) when backend returns a non-ok response', async () => {
+			mockBackendError();
+			await actions.batchDelete(makeEvent([1]) as any);
+			expect(fail).toHaveBeenCalledWith(500);
+		});
+
+		it('sets an error flash when backend returns a non-ok response', async () => {
+			mockBackendError('Cannot delete entity');
+			await actions.batchDelete(makeEvent([1]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'error' }),
+				mockCookies
+			);
+		});
+
+		it('error flash message includes the backend detail', async () => {
+			mockBackendError('Entity still in use');
+			await actions.batchDelete(makeEvent([1]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ message: expect.stringContaining('Entity still in use') }),
+				mockCookies
+			);
+		});
+
+		it('error flash message falls back to statusText when detail is missing', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Bad Gateway',
+				json: async () => ({})
+			});
+			await actions.batchDelete(makeEvent([1]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ message: expect.stringContaining('Bad Gateway') }),
+				mockCookies
+			);
+		});
+	});
+
+	// ── Error handling — network error ────────────────────────────────────────
+	describe('Error handling — network error', () => {
+		it('returns fail(500) on a network error', async () => {
+			mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+			await actions.batchDelete(makeEvent([1]) as any);
+			expect(fail).toHaveBeenCalledWith(500);
+		});
+
+		it('sets an error flash on a network error', async () => {
+			mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+			await actions.batchDelete(makeEvent([1]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'error' }),
+				mockCookies
+			);
+		});
+
+		it('error flash message mentions entity types on network failure', async () => {
+			mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+			await actions.batchDelete(makeEvent([1]) as any);
+			expect(setFlash).toHaveBeenCalledWith(
+				expect.objectContaining({ message: expect.stringContaining('entity types') }),
+				mockCookies
+			);
+		});
+	});
+});

--- a/src/routes/(admin)/entity/page.svelte.test.ts
+++ b/src/routes/(admin)/entity/page.svelte.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { render, screen,  } from '@testing-library/svelte';
+import { render, screen, within } from '@testing-library/svelte';
 import EntityListingPage from './+page.svelte';
 import { canCreate, } from '$lib/utils/permissions.js';
 
@@ -85,7 +85,7 @@ const sampleItems = [
 
 describe('Entity Listing Page', () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
+		vi.resetAllMocks();
 		(page as any).url = new URL('http://localhost/entity');
 	});
 
@@ -112,7 +112,8 @@ describe('Entity Listing Page', () => {
 		it('shows "Create Entity" button inside empty state when user has create permission', () => {
 			vi.mocked(canCreate).mockReturnValue(true);
 			render(EntityListingPage, { data: makeData([]) } as any);
-			expect(screen.getAllByRole('link', { name: /create entity/i }).length).toBeGreaterThan(0);
+			const emptyStateRegion = screen.getByText('No entities yet').closest('div') as HTMLElement;
+			expect(within(emptyStateRegion).getByRole('link', { name: /create entity/i })).toBeInTheDocument();
 		});
 
 		it('does not show create button inside empty state when user lacks create permission', () => {

--- a/src/routes/(admin)/entity/page.svelte.test.ts
+++ b/src/routes/(admin)/entity/page.svelte.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen,  } from '@testing-library/svelte';
+import EntityListingPage from './+page.svelte';
+import { canCreate, } from '$lib/utils/permissions.js';
+
+import { page } from '$app/state';
+
+vi.mock('$app/state', () => ({
+	page: {
+		url: new URL('http://localhost/entity')
+	}
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(),
+	invalidateAll: vi.fn()
+}));
+
+vi.mock('$app/forms', () => ({
+	enhance: vi.fn(() => () => {})
+}));
+
+vi.mock('$app/paths', () => ({
+	resolve: vi.fn((path: string) => path)
+}));
+
+vi.mock('$lib/constants', () => ({
+	DEFAULT_PAGE_SIZE: 25
+}));
+
+vi.mock('$lib/utils/permissions.js', () => ({
+	canCreate: vi.fn(() => false),
+	canUpdate: vi.fn(() => false),
+	canDelete: vi.fn(() => false)
+}));
+
+vi.mock('$lib/components/data-table/BatchActionsToolbar.svelte', () => ({
+	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
+}));
+
+vi.mock('$lib/components/data-table/index.js', () => ({
+	DataTable: vi.fn((_, props: any) => void props?.columns)
+}));
+
+const colRef = vi.hoisted(() => ({
+	handleSort: null as ((col: string) => void) | null,
+	enableSelection: undefined as boolean | undefined,
+	permissions: undefined as { canEdit?: boolean; canDelete?: boolean } | undefined
+}));
+
+vi.mock('./columns', () => ({
+	createColumns: vi.fn((...args: unknown[]) => {
+		colRef.handleSort = args[2] as (col: string) => void;
+		colRef.enableSelection = args[3] as boolean;
+		colRef.permissions = args[4] as { canEdit?: boolean; canDelete?: boolean };
+		return [];
+	})
+}));
+
+function makeData(
+	items: any[] = [],
+	params: Partial<{ search: string; isActive: string; sortBy: string; sortOrder: string }> = {}
+) {
+	return {
+		entities: { items, total: items.length, pages: items.length > 0 ? 1 : 0 },
+		totalPages: items.length > 0 ? 1 : 0,
+		params: {
+			page: 1,
+			size: 25,
+			search: '',
+			sortBy: '',
+			sortOrder: 'asc',
+			isActive: '',
+			...params
+		},
+		user: { id: 1, permissions: [] }
+	};
+}
+
+const sampleItems = [
+	{ id: 1, name: 'CLF', description: 'Community Level Federation', modified_date: '2026-06-01', total_records: 5 },
+	{ id: 2, name: 'SHG', description: 'Self Help Group', modified_date: '2026-06-02', total_records: 3 }
+];
+
+describe('Entity Listing Page', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(page as any).url = new URL('http://localhost/entity');
+	});
+
+	
+	describe('Page title', () => {
+		it('renders "Entities" as the page title', () => {
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.getByText('Entities')).toBeInTheDocument();
+		});
+	});
+
+
+	describe('Empty state', () => {
+		it('shows empty state heading when no items, no search, and no status filter', () => {
+			render(EntityListingPage, { data: makeData([]) } as any);
+			expect(screen.getByText('No entities yet')).toBeInTheDocument();
+		});
+
+		it('shows descriptive text in the empty state', () => {
+			render(EntityListingPage, { data: makeData([]) } as any);
+			expect(screen.getByText(/Create your first entity/i)).toBeInTheDocument();
+		});
+
+		it('shows "Create Entity" button inside empty state when user has create permission', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			render(EntityListingPage, { data: makeData([]) } as any);
+			expect(screen.getAllByRole('link', { name: /create entity/i }).length).toBeGreaterThan(0);
+		});
+
+		it('does not show create button inside empty state when user lacks create permission', () => {
+			vi.mocked(canCreate).mockReturnValue(false);
+			render(EntityListingPage, { data: makeData([]) } as any);
+			expect(screen.queryByRole('link', { name: /create entity/i })).not.toBeInTheDocument();
+		});
+
+		it('does not show empty state when items exist', () => {
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.queryByText('No entities yet')).not.toBeInTheDocument();
+		});
+
+		it('does not show empty state when search is set even with 0 results', () => {
+			render(EntityListingPage, { data: makeData([], { search: 'xyz' }) } as any);
+			expect(screen.queryByText('No entities yet')).not.toBeInTheDocument();
+		});
+
+		it('does not show empty state when isActive filter is set even with 0 results', () => {
+			render(EntityListingPage, { data: makeData([], { isActive: 'true' }) } as any);
+			expect(screen.queryByText('No entities yet')).not.toBeInTheDocument();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Create button (header)', () => {
+		it('shows "Create Entity" header button when user has permission and items exist', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.getByRole('link', { name: /create entity/i })).toBeInTheDocument();
+		});
+
+		it('does not show "Create Entity" header button when user lacks permission', () => {
+			vi.mocked(canCreate).mockReturnValue(false);
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.queryByRole('link', { name: /create entity/i })).not.toBeInTheDocument();
+		});
+
+		it('create button links to /entity/add/new', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			const link = screen.getByRole('link', { name: /create entity/i });
+			expect(link).toHaveAttribute('href', '/entity/add/new');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Search input', () => {
+		it('renders search input with placeholder "Search entities..."', () => {
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.getByPlaceholderText('Search entities...')).toBeInTheDocument();
+		});
+
+		it('reflects the current search value from params', () => {
+			render(EntityListingPage, { data: makeData(sampleItems, { search: 'CLF' }) } as any);
+			expect(screen.getByPlaceholderText('Search entities...')).toHaveValue('CLF');
+		});
+
+		it('shows empty value when search param is empty', () => {
+			render(EntityListingPage, { data: makeData(sampleItems, { search: '' }) } as any);
+			expect(screen.getByPlaceholderText('Search entities...')).toHaveValue('');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Status filter', () => {
+		it('renders a "Status" button when no filter is active', () => {
+			render(EntityListingPage, { data: makeData(sampleItems, { isActive: '' }) } as any);
+			expect(screen.getByRole('button', { name: /status/i })).toBeInTheDocument();
+		});
+
+		it('renders "Active" label when isActive is "true"', () => {
+			render(EntityListingPage, { data: makeData(sampleItems, { isActive: 'true' }) } as any);
+			expect(screen.getByRole('button', { name: /active/i })).toBeInTheDocument();
+		});
+
+		it('renders "Inactive" label when isActive is "false"', () => {
+			render(EntityListingPage, { data: makeData(sampleItems, { isActive: 'false' }) } as any);
+			expect(screen.getByRole('button', { name: /inactive/i })).toBeInTheDocument();
+		});
+	});
+
+
+	
+});


### PR DESCRIPTION
fixes #486 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added UI tests for the Entity listing page: title, empty-state messaging, conditional "Create" link, search input sync with params, and status filter labels/behavior.
  * Added server-side tests for listing and batch-delete flows: permission checks, backend request/response handling, pagination/param mapping, success/error flash messages, and error handling.
  * Added form and record-list UI tests: add/edit form behavior, field prefill/validation, back links, save button enablement, record listing, selection/sorting, and batch-delete form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->