### PR TITLE
Fix mobile layout for delete confirmation dialogs

### DIFF
--- a/src/lib/components/DeleteDialog.svelte
+++ b/src/lib/components/DeleteDialog.svelte
@@ -86,11 +86,12 @@
 			</AlertDialog.Description>
 		</div>
 
-		<AlertDialog.Footer class="flex-row justify-end gap-2 p-6 pt-0">
+		<AlertDialog.Footer class="flex-row gap-2 p-6 pt-0">
 			{#if batchMode}
 				<AlertDialog.Cancel
 					type="button"
 					onclick={handleClose}
+					class="flex-1 sm:flex-none"
 				>
 					Cancel
 				</AlertDialog.Cancel>
@@ -98,6 +99,7 @@
 				<Button
 					variant="destructive"
 					onclick={handleBatchConfirm}
+					class="flex-1 sm:flex-none"
 				>
 					Delete {selectedCount} {elementName}
 				</Button>
@@ -105,14 +107,20 @@
 				<AlertDialog.Cancel
 					type="button"
 					onclick={handleClose}
+					class="flex-1 sm:flex-none"
 				>
 					Cancel
 				</AlertDialog.Cancel>
 
-				<form {action} method="POST">
+				<form
+					{action}
+					method="POST"
+					class="flex-1 sm:flex-none"
+				>
 					<Button
 						variant="destructive"
 						type="submit"
+						class="w-full"
 					>
 						Delete
 					</Button>

--- a/src/lib/components/DeleteDialog.svelte
+++ b/src/lib/components/DeleteDialog.svelte
@@ -86,17 +86,36 @@
 			</AlertDialog.Description>
 		</div>
 
-		<AlertDialog.Footer class="p-6 pt-0">
+		<AlertDialog.Footer class="flex-row justify-end gap-2 p-6 pt-0">
 			{#if batchMode}
-				<AlertDialog.Cancel type="button" onclick={handleClose}>Cancel</AlertDialog.Cancel>
-				<Button variant="destructive" onclick={handleBatchConfirm}>
-					Delete {selectedCount}
-					{elementName}
+				<AlertDialog.Cancel
+					type="button"
+					onclick={handleClose}
+				>
+					Cancel
+				</AlertDialog.Cancel>
+
+				<Button
+					variant="destructive"
+					onclick={handleBatchConfirm}
+				>
+					Delete {selectedCount} {elementName}
 				</Button>
 			{:else}
-				<AlertDialog.Cancel type="button" onclick={handleClose}>Cancel</AlertDialog.Cancel>
+				<AlertDialog.Cancel
+					type="button"
+					onclick={handleClose}
+				>
+					Cancel
+				</AlertDialog.Cancel>
+
 				<form {action} method="POST">
-					<Button variant="destructive" type="submit">Delete</Button>
+					<Button
+						variant="destructive"
+						type="submit"
+					>
+						Delete
+					</Button>
 				</form>
 			{/if}
 		</AlertDialog.Footer>

--- a/src/routes/(admin)/tags/TagDeleteDialog.svelte
+++ b/src/routes/(admin)/tags/TagDeleteDialog.svelte
@@ -45,7 +45,7 @@
 			<AlertDialog.Description>{description}</AlertDialog.Description>
 		</div>
 
-		<AlertDialog.Footer class="p-6 pt-0">
+		<AlertDialog.Footer class="flex-row justify-end gap-2 p-6 pt-0">
 			<AlertDialog.Cancel type="button" onclick={() => (open = false)}>Cancel</AlertDialog.Cancel>
 			<form
 				method="POST"

--- a/src/routes/(admin)/tags/TagDeleteDialog.svelte
+++ b/src/routes/(admin)/tags/TagDeleteDialog.svelte
@@ -45,11 +45,19 @@
 			<AlertDialog.Description>{description}</AlertDialog.Description>
 		</div>
 
-		<AlertDialog.Footer class="flex-row justify-end gap-2 p-6 pt-0">
-			<AlertDialog.Cancel type="button" onclick={() => (open = false)}>Cancel</AlertDialog.Cancel>
+		<AlertDialog.Footer class="flex-row gap-2 p-6 pt-0">
+			<AlertDialog.Cancel
+				type="button"
+				onclick={() => (open = false)}
+				class="flex-1 sm:flex-none"
+			>
+				Cancel
+			</AlertDialog.Cancel>
+
 			<form
 				method="POST"
 				{action}
+				class="flex-1 sm:flex-none"
 				use:enhance={() => {
 					return async ({ update }) => {
 						open = false;
@@ -58,7 +66,14 @@
 				}}
 			>
 				<input type="hidden" name="id" value={elementId} />
-				<Button variant="destructive" type="submit">Delete</Button>
+
+				<Button
+					variant="destructive"
+					type="submit"
+					class="w-full"
+				>
+					Delete
+				</Button>
 			</form>
 		</AlertDialog.Footer>
 	</AlertDialog.Content>


### PR DESCRIPTION
## Related Issue

Fixes #523 

---

## Description

This PR resolves the mobile layout issue in delete confirmation dialogs.

Previously, action buttons in delete dialogs were displayed vertically on mobile devices due to the responsive footer layout. This resulted in inconsistent button alignment and did not match the expected mobile design.

The footer layout has been updated specifically for delete confirmation dialogs to ensure action buttons remain horizontally aligned on mobile devices while preserving existing desktop behavior.

---

## Changes Made

### Delete Confirmation Dialog

- Updated footer layout for mobile viewports
- Ensured action buttons are displayed side-by-side
- Improved consistency of action button alignment

### Tag Deletion Dialog

- Applied the same mobile layout fix
- Maintained consistent behavior across delete flows

---

## Before

- Action buttons were stacked vertically on mobile devices
- Layout was inconsistent across delete confirmation dialogs
- Mobile experience did not match the expected design

## After

- Action buttons are displayed side-by-side on mobile devices
- Consistent layout across delete confirmation dialogs
- Improved mobile user experience


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Enhanced the visual layout and button spacing in delete confirmation dialogs to improve consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->