### PR TITLE
Fix long tag name display in tag management

### DIFF
--- a/src/lib/components/ui/tag-chip/TagChip.svelte
+++ b/src/lib/components/ui/tag-chip/TagChip.svelte
@@ -2,6 +2,7 @@
 	import { cn } from '$lib/utils';
 	import type { Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
+	import TruncatedTextCell from '$lib/components/data-table/TruncatedTextCell.svelte';
 
 	let {
 		name,
@@ -17,12 +18,12 @@
 <span
 	data-slot="tag-chip"
 	class={cn(
-		'bg-muted text-muted-foreground inline-flex max-w-full items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
+		'bg-muted text-muted-foreground inline-flex max-w-45 items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
 		className
 	)}
 	{...restProps}
 >
-	<span class="whitespace-normal break-all">{name}</span>
+	<TruncatedTextCell value={name} />
 	{#if children}
 		{@render children()}
 	{/if}

--- a/src/lib/components/ui/tag-chip/TagChip.svelte
+++ b/src/lib/components/ui/tag-chip/TagChip.svelte
@@ -17,12 +17,12 @@
 <span
 	data-slot="tag-chip"
 	class={cn(
-		'bg-muted text-muted-foreground inline-flex items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
+		'bg-muted text-muted-foreground inline-flex max-w-full items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
 		className
 	)}
 	{...restProps}
 >
-	<span class="truncate">{name}</span>
+	<span class="whitespace-normal break-all">{name}</span>
 	{#if children}
 		{@render children()}
 	{/if}


### PR DESCRIPTION
## Fixes #502

---

### Description

This PR improves the handling of long tag names in the Tag Management interface to ensure that full tag text remains visible without affecting the overall layout.

---

### Changes Made

- Updated tag chip rendering to support long tag names.
- Enabled proper text wrapping for lengthy tag labels.
- Prevented tag content from overflowing or being truncated.
- Preserved visibility and accessibility of edit and delete actions.
- Maintained consistent layout across different tag lengths.

---


### Screenshots
Before #509 
<img width="1077" height="365" alt="image" src="https://github.com/user-attachments/assets/e232ec90-ba65-4ec0-af49-9d86f65fe098" />

After :-
<img width="1901" height="892" alt="Screenshot 2026-06-21 000939" src="https://github.com/user-attachments/assets/a68fbfff-6a34-423c-b179-ba05a14e9c5d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced text truncation behavior in tag chips for improved visual consistency and display alignment. The component now handles text overflow more effectively, ensuring proper rendering and maintaining consistent appearance across all tag chip instances throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->