### PR TITLE
Add custom nomenclature support for various components in tests

### DIFF
--- a/src/lib/components/app-sidebar.svelte.test.ts
+++ b/src/lib/components/app-sidebar.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import AppSidebar from './app-sidebar.svelte';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('$app/navigation', () => ({
 	goto: vi.fn()
@@ -23,6 +24,11 @@ vi.mock('$lib/components/ui/sidebar/context.svelte.js', () => ({
 		setOpenMobile: vi.fn()
 	}))
 }));
+
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 const baseData = {
 	user: { id: 1, permissions: [] },
@@ -85,5 +91,75 @@ describe('AppSidebar - Organization Branding', () => {
 		expect(screen.getByRole('img')).toBeInTheDocument();
 		expect(screen.queryByText('Sashakt')).not.toBeInTheDocument();
 		expect(screen.queryByText('Acme Corp')).not.toBeInTheDocument();
+	});
+});
+
+describe('AppSidebar - Custom nomenclature labels', () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		resetNomenclature();
+		const permissions = await import('$lib/utils/permissions.js');
+		vi.mocked(permissions.canCreate).mockReturnValue(true);
+		vi.mocked(permissions.canRead).mockReturnValue(true);
+	});
+
+	it('renders custom sidebar label when tests is overridden', () => {
+		setCustomNomenclature({ tests: 'Assessments' });
+		render(AppSidebar, { data: baseData });
+		expect(screen.getByText('Assessments')).toBeInTheDocument();
+		expect(screen.queryByText('Tests')).not.toBeInTheDocument();
+	});
+
+	it('renders custom sidebar label when question_bank is overridden', () => {
+		setCustomNomenclature({ question_bank: 'Knowledge Base' });
+		render(AppSidebar, { data: baseData });
+		expect(screen.getByText('Knowledge Base')).toBeInTheDocument();
+		expect(screen.queryByText('Question Bank')).not.toBeInTheDocument();
+	});
+
+	it('renders custom sidebar label when tag_management is overridden', () => {
+		setCustomNomenclature({ tag_management: 'Categories' });
+		render(AppSidebar, { data: baseData });
+		expect(screen.getByText('Categories')).toBeInTheDocument();
+		expect(screen.queryByText('Tag Management')).not.toBeInTheDocument();
+	});
+
+	it('renders custom sidebar label when certificates is overridden', () => {
+		setCustomNomenclature({ certificates: 'Awards' });
+		render(AppSidebar, { data: baseData });
+		expect(screen.getByText('Awards')).toBeInTheDocument();
+		expect(screen.queryByText('Certificates')).not.toBeInTheDocument();
+	});
+
+	it('renders custom sidebar label when entities is overridden', () => {
+		setCustomNomenclature({ entities: 'Groups' });
+		render(AppSidebar, { data: baseData });
+		expect(screen.getByText('Groups')).toBeInTheDocument();
+		expect(screen.queryByText('Entities')).not.toBeInTheDocument();
+	});
+
+	it('renders custom sidebar label when forms is overridden', () => {
+		setCustomNomenclature({ forms: 'Surveys' });
+		render(AppSidebar, { data: baseData });
+		expect(screen.getByText('Surveys')).toBeInTheDocument();
+		expect(screen.queryByText('Forms')).not.toBeInTheDocument();
+	});
+
+	it('applies multiple custom nomenclature overrides simultaneously', () => {
+		setCustomNomenclature({
+			tests: 'Exams',
+			question_bank: 'Library',
+			certificates: 'Awards'
+		});
+		render(AppSidebar, { data: baseData });
+		expect(screen.getByText('Exams')).toBeInTheDocument();
+		expect(screen.getByText('Library')).toBeInTheDocument();
+		expect(screen.getByText('Awards')).toBeInTheDocument();
+	});
+
+	it('falls back to defaults when no custom nomenclature is set', () => {
+		render(AppSidebar, { data: baseData });
+		expect(screen.getByText('Tests')).toBeInTheDocument();
+		expect(screen.getByText('Question Bank')).toBeInTheDocument();
 	});
 });

--- a/src/lib/test-utils/nomenclature-mock.ts
+++ b/src/lib/test-utils/nomenclature-mock.ts
@@ -1,0 +1,44 @@
+const DEFAULTS: Record<string, string> = {
+	dashboard: 'Dashboard',
+	question_bank: 'Question Bank',
+	tag_management: 'Tag Management',
+	tests: 'Tests',
+	test: 'Test',
+	tags: 'Tags',
+	tag: 'Tag',
+	test_templates: 'Test Templates',
+	test_template: 'Test Template',
+	tag_types: 'Tag Types',
+	tag_type: 'Tag Type',
+	forms: 'Forms',
+	form: 'Form',
+	certificates: 'Certificates',
+	certificate: 'Certificate',
+	entities: 'Entities',
+	entity: 'Entity',
+	organisations: 'Organisations',
+	users: 'Users',
+	user: 'User'
+};
+
+export const mockTermMap: Record<string, string> = {};
+
+export function createNomenclatureMock() {
+	return {
+		useTerms: () => (key: string, casing?: string) => {
+			const label = mockTermMap[key] ?? DEFAULTS[key] ?? key;
+			if (casing === 'lower') return label.toLowerCase();
+			if (casing === 'upper') return label.toUpperCase();
+			return label;
+		}
+	};
+}
+
+export function setCustomNomenclature(overrides: Record<string, string>) {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+	Object.assign(mockTermMap, overrides);
+}
+
+export function resetNomenclature() {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+}

--- a/src/routes/(admin)/certificate/[action]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/certificate/[action]/[id]/page.svelte.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import CertificateFormPage from './+page.svelte';
 import { superForm } from 'sveltekit-superforms';
 import { zod4Client } from 'sveltekit-superforms/adapters';
 import { createCertificateSchema, editCertificateSchema } from './schema.js';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('sveltekit-superforms', () => ({
 	superForm: vi.fn((data) => ({
@@ -39,6 +40,11 @@ vi.mock('./schema.js', () => ({
 	editCertificateSchema: 'editSchema',
 	certificateSchema: 'createSchema'
 }));
+
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 function makeFormStore(values: Record<string, unknown>, errors: Record<string, string> = {}) {
 	vi.mocked(superForm).mockImplementationOnce(() => ({
@@ -211,5 +217,53 @@ describe('CertificateFormPage', () => {
 	it('passes editCertificateSchema to zod4Client in edit mode', () => {
 		render(CertificateFormPage, { data: editModeData });
 		expect(vi.mocked(zod4Client)).toHaveBeenCalledWith(editCertificateSchema);
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Custom nomenclature labels', () => {
+		afterEach(() => {
+			resetNomenclature();
+		});
+
+		it('renders custom heading in add mode when certificate is overridden', () => {
+			setCustomNomenclature({ certificate: 'Award' });
+			render(CertificateFormPage, { data: addModeData });
+			expect(screen.getByRole('heading', { name: /create award/i })).toBeInTheDocument();
+			expect(screen.queryByRole('heading', { name: /create certificate/i })).not.toBeInTheDocument();
+		});
+
+		it('renders custom heading in edit mode when certificate is overridden', () => {
+			setCustomNomenclature({ certificate: 'Award' });
+			render(CertificateFormPage, { data: editModeData });
+			expect(screen.getByRole('heading', { name: /edit award/i })).toBeInTheDocument();
+		});
+
+		it('renders custom field labels when certificate is overridden', () => {
+			setCustomNomenclature({ certificate: 'Award' });
+			render(CertificateFormPage, { data: addModeData });
+			expect(screen.getByText('Award Name')).toBeInTheDocument();
+			expect(screen.getByText('Award URL')).toBeInTheDocument();
+			expect(screen.getByText('Award Status')).toBeInTheDocument();
+		});
+
+		it('renders custom section heading when certificate is overridden', () => {
+			setCustomNomenclature({ certificate: 'Award' });
+			render(CertificateFormPage, { data: addModeData });
+			expect(screen.getByText('Award Details')).toBeInTheDocument();
+			expect(screen.queryByText('Certificate Details')).not.toBeInTheDocument();
+		});
+
+		it('renders custom back link label when certificates is overridden', () => {
+			setCustomNomenclature({ certificates: 'Awards' });
+			const { container } = render(CertificateFormPage, { data: addModeData });
+			const backLink = container.querySelector('a[aria-label="Back to awards"]');
+			expect(backLink).toBeInTheDocument();
+		});
+
+		it('falls back to defaults when no custom nomenclature is set', () => {
+			render(CertificateFormPage, { data: addModeData });
+			expect(screen.getByRole('heading', { name: /create certificate/i })).toBeInTheDocument();
+			expect(screen.getByText('Certificate Details')).toBeInTheDocument();
+		});
 	});
 });

--- a/src/routes/(admin)/certificate/page.svelte.test.ts
+++ b/src/routes/(admin)/certificate/page.svelte.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import CertificatePage from './+page.svelte';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 const baseData = {
 	certificates: {
@@ -31,6 +32,11 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	canUpdate: vi.fn(),
 	canDelete: vi.fn()
 }));
+
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 describe('CertificatePage', () => {
 	it('renders certificate management page', () => {
@@ -152,5 +158,59 @@ describe('CertificatePage – bulk delete feature', () => {
 			'#batch-delete-form input[name="certificateIds"]'
 		) as HTMLInputElement;
 		expect(input.value).toBe('[]');
+	});
+});
+
+describe('CertificatePage – Custom nomenclature labels', () => {
+	afterEach(() => {
+		resetNomenclature();
+	});
+
+	it('renders custom page heading when certificates is overridden', () => {
+		setCustomNomenclature({ certificates: 'Awards' });
+		render(CertificatePage, { data: baseData });
+		expect(screen.getByRole('heading', { name: /Awards/i })).toBeInTheDocument();
+		expect(screen.queryByRole('heading', { name: /Certificates/i })).not.toBeInTheDocument();
+	});
+
+	it('renders custom create button label when certificate is overridden', async () => {
+		setCustomNomenclature({ certificate: 'Award' });
+		const permissions = await import('$lib/utils/permissions.js');
+		vi.mocked(permissions.canCreate).mockReturnValue(true);
+		render(CertificatePage, { data: baseData });
+		expect(screen.getByText(/Create Award/i)).toBeInTheDocument();
+	});
+
+	it('renders custom empty state text when certificates/certificate are overridden', () => {
+		setCustomNomenclature({ certificates: 'Awards', certificate: 'Award' });
+		render(CertificatePage, {
+			data: {
+				...baseData,
+				certificates: { items: [], total: 0, pages: 0 }
+			}
+		});
+		expect(screen.getByText(/No awards yet/i)).toBeInTheDocument();
+	});
+
+	it('renders custom search placeholder when certificates is overridden', () => {
+		setCustomNomenclature({ certificates: 'Awards' });
+		render(CertificatePage, { data: baseData });
+		expect(screen.getByPlaceholderText('Search awards...')).toBeInTheDocument();
+	});
+
+	it('renders custom test label in empty state description', () => {
+		setCustomNomenclature({ certificates: 'Awards', certificate: 'Award', test: 'Exam' });
+		render(CertificatePage, {
+			data: {
+				...baseData,
+				certificates: { items: [], total: 0, pages: 0 }
+			}
+		});
+		expect(screen.getByText(/complete a exam/i)).toBeInTheDocument();
+	});
+
+	it('falls back to defaults when no custom nomenclature is set', () => {
+		render(CertificatePage, { data: baseData });
+		expect(screen.getByRole('heading', { name: /Certificates/i })).toBeInTheDocument();
 	});
 });

--- a/src/routes/(admin)/dashboard/page.svelte.test.ts
+++ b/src/routes/(admin)/dashboard/page.svelte.test.ts
@@ -1,9 +1,44 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import Dashboard from './+page.svelte';
 
+const mockTermMap: Record<string, string> = {};
+
+vi.mock('$lib/nomenclature', () => ({
+	useTerms: () => (key: string, casing?: string) => {
+		const label =
+			mockTermMap[key] ??
+			{
+				dashboard: 'Dashboard',
+				tests: 'Tests',
+				test: 'Test',
+				users: 'Users',
+				user: 'User',
+				question_bank: 'Question Bank',
+				test_templates: 'Test Templates'
+			}[key] ??
+			key;
+		if (casing === 'lower') return label.toLowerCase();
+		if (casing === 'upper') return label.toUpperCase();
+		return label;
+	}
+}));
+
+function setCustomNomenclature(overrides: Record<string, string>) {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+	Object.assign(mockTermMap, overrides);
+}
+
+function resetNomenclature() {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+}
+
 describe('Dashboard.svelte', () => {
+	afterEach(() => {
+		resetNomenclature();
+	});
+
 	it('renders "No of Tests" text on the page', () => {
 		render(Dashboard);
 		expect(screen.getByText('No of Tests')).toBeInTheDocument();
@@ -74,5 +109,57 @@ describe('Dashboard.svelte', () => {
 		expect(container.textContent).toContain('8');
 		expect(container.textContent).toContain('2');
 		expect(container.textContent).toContain('1');
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Custom nomenclature labels', () => {
+		it('renders custom dashboard heading when nomenclature is overridden', () => {
+			setCustomNomenclature({ dashboard: 'Home' });
+			render(Dashboard);
+			expect(screen.getByRole('heading', { name: 'Home' })).toBeInTheDocument();
+			expect(screen.queryByRole('heading', { name: 'Dashboard' })).not.toBeInTheDocument();
+		});
+
+		it('renders custom test label in stats box', () => {
+			setCustomNomenclature({ tests: 'Exams' });
+			render(Dashboard);
+			expect(screen.getByText('No of Exams')).toBeInTheDocument();
+			expect(screen.queryByText('No of Tests')).not.toBeInTheDocument();
+		});
+
+		it('renders custom users label in stats box', () => {
+			setCustomNomenclature({ users: 'Members' });
+			render(Dashboard);
+			expect(screen.getByText('No of Members')).toBeInTheDocument();
+			expect(screen.queryByText('No of Users')).not.toBeInTheDocument();
+		});
+
+		it('renders custom test label in test attempts summary', () => {
+			setCustomNomenclature({ test: 'Exam' });
+			render(Dashboard);
+			expect(screen.getByText('Summary of Exam Attempts')).toBeInTheDocument();
+			expect(screen.queryByText('Summary of Test Attempts')).not.toBeInTheDocument();
+		});
+
+		it('applies multiple custom nomenclature overrides simultaneously', () => {
+			setCustomNomenclature({
+				dashboard: 'Control Panel',
+				tests: 'Assessments',
+				users: 'Learners',
+				test: 'Assessment'
+			});
+			render(Dashboard);
+			expect(screen.getByRole('heading', { name: 'Control Panel' })).toBeInTheDocument();
+			expect(screen.getByText('No of Assessments')).toBeInTheDocument();
+			expect(screen.getByText('No of Learners')).toBeInTheDocument();
+			expect(screen.getByText('Summary of Assessment Attempts')).toBeInTheDocument();
+		});
+
+		it('falls back to default when custom nomenclature is reset', () => {
+			setCustomNomenclature({ dashboard: 'Home' });
+			resetNomenclature();
+			render(Dashboard);
+			expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
+		});
 	});
 });

--- a/src/routes/(admin)/dashboard/page.svelte.test.ts
+++ b/src/routes/(admin)/dashboard/page.svelte.test.ts
@@ -2,37 +2,12 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import Dashboard from './+page.svelte';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
-const mockTermMap: Record<string, string> = {};
-
-vi.mock('$lib/nomenclature', () => ({
-	useTerms: () => (key: string, casing?: string) => {
-		const label =
-			mockTermMap[key] ??
-			{
-				dashboard: 'Dashboard',
-				tests: 'Tests',
-				test: 'Test',
-				users: 'Users',
-				user: 'User',
-				question_bank: 'Question Bank',
-				test_templates: 'Test Templates'
-			}[key] ??
-			key;
-		if (casing === 'lower') return label.toLowerCase();
-		if (casing === 'upper') return label.toUpperCase();
-		return label;
-	}
-}));
-
-function setCustomNomenclature(overrides: Record<string, string>) {
-	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
-	Object.assign(mockTermMap, overrides);
-}
-
-function resetNomenclature() {
-	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
-}
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 describe('Dashboard.svelte', () => {
 	afterEach(() => {

--- a/src/routes/(admin)/entity/[action]/[id]/EntityForm.svelte.test.ts
+++ b/src/routes/(admin)/entity/[action]/[id]/EntityForm.svelte.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { writable } from 'svelte/store';
 import EntityForm from './EntityForm.svelte';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('$app/paths', () => ({
 	resolve: vi.fn((path: string) => path)
@@ -12,6 +13,11 @@ vi.mock('$app/paths', () => ({
 vi.mock('sveltekit-superforms/adapters', () => ({
 	zod4Client: vi.fn((schema) => schema)
 }));
+
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 const superFormRef = vi.hoisted(() => ({
 	errors: null as ReturnType<typeof writable> | null
@@ -239,6 +245,58 @@ describe('EntityForm', () => {
 			await tick();
 
 			expect(screen.queryByText('Entity name is required')).not.toBeInTheDocument();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Custom nomenclature labels', () => {
+		afterEach(() => {
+			resetNomenclature();
+		});
+
+		it('renders custom heading in add mode when entity is overridden', () => {
+			setCustomNomenclature({ entity: 'Group' });
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByText('Create Group')).toBeInTheDocument();
+			expect(screen.queryByText('Create Entity')).not.toBeInTheDocument();
+		});
+
+		it('renders custom heading in edit mode when entity is overridden', () => {
+			setCustomNomenclature({ entity: 'Group' });
+			render(EntityForm, { data: editData } as any);
+			expect(screen.getByText('Edit Group')).toBeInTheDocument();
+		});
+
+		it('renders custom back link label when entities is overridden', () => {
+			setCustomNomenclature({ entities: 'Groups' });
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByRole('link', { name: /back to groups/i })).toBeInTheDocument();
+		});
+
+		it('renders custom name label when entity is overridden', () => {
+			setCustomNomenclature({ entity: 'Group' });
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByText('Group Name')).toBeInTheDocument();
+			expect(screen.queryByText('Entity Name')).not.toBeInTheDocument();
+		});
+
+		it('renders custom save button label when entity is overridden', () => {
+			setCustomNomenclature({ entity: 'Group' });
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByRole('button', { name: /save group/i })).toBeInTheDocument();
+		});
+
+		it('renders custom placeholder when entity is overridden', () => {
+			setCustomNomenclature({ entity: 'Group' });
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByPlaceholderText('Name of this group...')).toBeInTheDocument();
+			expect(screen.getByPlaceholderText('Brief description of this group...')).toBeInTheDocument();
+		});
+
+		it('falls back to defaults when no custom nomenclature is set', () => {
+			render(EntityForm, { data: createData } as any);
+			expect(screen.getByText('Create Entity')).toBeInTheDocument();
+			expect(screen.getByText('Entity Name')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/routes/(admin)/entity/[action]/[id]/EntityForm.svelte.test.ts
+++ b/src/routes/(admin)/entity/[action]/[id]/EntityForm.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
+import type { ComponentProps } from 'svelte';
 import { tick } from 'svelte';
 import { writable } from 'svelte/store';
 import EntityForm from './EntityForm.svelte';
@@ -51,6 +52,10 @@ const editData = {
 	form: makeForm({ name: 'CLF', description: 'Community Level Federation' })
 };
 
+function renderEntityForm(data: typeof createData | typeof editData) {
+	return render(EntityForm, { data } as ComponentProps<typeof EntityForm>);
+}
+
 describe('EntityForm', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -60,22 +65,22 @@ describe('EntityForm', () => {
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Page title', () => {
 		it('shows "Create Entity" heading in add mode', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByText('Create Entity')).toBeInTheDocument();
 		});
 
 		it('shows "Edit Entity" heading in edit mode', () => {
-			render(EntityForm, { data: editData } as any);
+			renderEntityForm(editData);
 			expect(screen.getByText('Edit Entity')).toBeInTheDocument();
 		});
 
 		it('does not show "Edit Entity" heading in add mode', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.queryByText('Edit Entity')).not.toBeInTheDocument();
 		});
 
 		it('does not show "Create Entity" heading in edit mode', () => {
-			render(EntityForm, { data: editData } as any);
+			renderEntityForm(editData);
 			expect(screen.queryByText('Create Entity')).not.toBeInTheDocument();
 		});
 	});
@@ -83,12 +88,12 @@ describe('EntityForm', () => {
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Back link', () => {
 		it('renders a back link', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByRole('link', { name: /back to entities/i })).toBeInTheDocument();
 		});
 
 		it('back link points to /entity', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			const link = screen.getByRole('link', { name: /back to entities/i });
 			expect(link).toHaveAttribute('href', '/entity');
 		});
@@ -97,13 +102,13 @@ describe('EntityForm', () => {
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Form attributes', () => {
 		it('form has method POST', () => {
-			const { container } = render(EntityForm, { data: createData } as any);
+			const { container } = renderEntityForm(createData);
 			const form = container.querySelector('form');
 			expect(form).toHaveAttribute('method', 'POST');
 		});
 
 		it('form has action ?/save', () => {
-			const { container } = render(EntityForm, { data: createData } as any);
+			const { container } = renderEntityForm(createData);
 			const form = container.querySelector('form');
 			expect(form).toHaveAttribute('action', '?/save');
 		});
@@ -112,28 +117,28 @@ describe('EntityForm', () => {
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Name field', () => {
 		it('renders the Name label', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByText('Entity Name')).toBeInTheDocument();
 		});
 
 		it('renders the name input', () => {
-			const { container } = render(EntityForm, { data: createData } as any);
+			const { container } = renderEntityForm(createData);
 			expect(container.querySelector('input[name="name"]')).toBeInTheDocument();
 		});
 
 		it('name input has correct placeholder in add mode', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByPlaceholderText('Name of this entity...')).toBeInTheDocument();
 		});
 
 		it('name input is empty in add mode', () => {
-			const { container } = render(EntityForm, { data: createData } as any);
+			const { container } = renderEntityForm(createData);
 			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
 			expect(input.value).toBe('');
 		});
 
 		it('name input is pre-filled in edit mode', () => {
-			const { container } = render(EntityForm, { data: editData } as any);
+			const { container } = renderEntityForm(editData);
 			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
 			expect(input.value).toBe('CLF');
 		});
@@ -142,24 +147,24 @@ describe('EntityForm', () => {
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Description field', () => {
 		it('renders the Description label', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByText('Description')).toBeInTheDocument();
 		});
 
 		it('renders the description textarea', () => {
-			const { container } = render(EntityForm, { data: createData } as any);
+			const { container } = renderEntityForm(createData);
 			expect(container.querySelector('textarea[name="description"]')).toBeInTheDocument();
 		});
 
 		it('description textarea has correct placeholder', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(
 				screen.getByPlaceholderText('Brief description of this entity...')
 			).toBeInTheDocument();
 		});
 
 		it('description textarea is empty in add mode', () => {
-			const { container } = render(EntityForm, { data: createData } as any);
+			const { container } = renderEntityForm(createData);
 			const textarea = container.querySelector(
 				'textarea[name="description"]'
 			) as HTMLTextAreaElement;
@@ -167,7 +172,7 @@ describe('EntityForm', () => {
 		});
 
 		it('description textarea is pre-filled in edit mode', () => {
-			const { container } = render(EntityForm, { data: editData } as any);
+			const { container } = renderEntityForm(editData);
 			const textarea = container.querySelector(
 				'textarea[name="description"]'
 			) as HTMLTextAreaElement;
@@ -178,29 +183,27 @@ describe('EntityForm', () => {
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Save button', () => {
 		it('renders the Save button with label "Save Entity"', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByRole('button', { name: /save entity/i })).toBeInTheDocument();
 		});
 
 		it('Save button is DISABLED when name is empty', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByRole('button', { name: /save entity/i })).toBeDisabled();
 		});
 
 		it('Save button is DISABLED when name is only whitespace', () => {
-			render(EntityForm, {
-				data: { ...createData, form: makeForm({ name: '   ' }) }
-			} as any);
+			renderEntityForm({ ...createData, form: makeForm({ name: '   ' }) });
 			expect(screen.getByRole('button', { name: /save entity/i })).toBeDisabled();
 		});
 
 		it('Save button is ENABLED when name has a value in edit mode', () => {
-			render(EntityForm, { data: editData } as any);
+			renderEntityForm(editData);
 			expect(screen.getByRole('button', { name: /save entity/i })).toBeEnabled();
 		});
 
 		it('Save button becomes ENABLED after the user types a name', async () => {
-			const { container } = render(EntityForm, { data: createData } as any);
+			const { container } = renderEntityForm(createData);
 			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
 
 			await fireEvent.input(input, { target: { value: 'New Entity' } });
@@ -210,7 +213,7 @@ describe('EntityForm', () => {
 		});
 
 		it('Save button becomes DISABLED again when name is cleared', async () => {
-			const { container } = render(EntityForm, { data: editData } as any);
+			const { container } = renderEntityForm(editData);
 			const input = container.querySelector('input[name="name"]') as HTMLInputElement;
 
 			await fireEvent.input(input, { target: { value: '' } });
@@ -223,12 +226,12 @@ describe('EntityForm', () => {
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Validation error display', () => {
 		it('does NOT show a name error message when there are no errors', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.queryByText('Entity name is required')).not.toBeInTheDocument();
 		});
 
 		it('shows the name error message when $errors.name is set', async () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 
 			superFormRef.errors!.set({ name: ['Entity name is required'] });
 			await tick();
@@ -237,7 +240,7 @@ describe('EntityForm', () => {
 		});
 
 		it('clears the name error message when $errors.name is removed', async () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 
 			superFormRef.errors!.set({ name: ['Entity name is required'] });
 			await tick();
@@ -256,45 +259,45 @@ describe('EntityForm', () => {
 
 		it('renders custom heading in add mode when entity is overridden', () => {
 			setCustomNomenclature({ entity: 'Group' });
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByText('Create Group')).toBeInTheDocument();
 			expect(screen.queryByText('Create Entity')).not.toBeInTheDocument();
 		});
 
 		it('renders custom heading in edit mode when entity is overridden', () => {
 			setCustomNomenclature({ entity: 'Group' });
-			render(EntityForm, { data: editData } as any);
+			renderEntityForm(editData);
 			expect(screen.getByText('Edit Group')).toBeInTheDocument();
 		});
 
 		it('renders custom back link label when entities is overridden', () => {
 			setCustomNomenclature({ entities: 'Groups' });
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByRole('link', { name: /back to groups/i })).toBeInTheDocument();
 		});
 
 		it('renders custom name label when entity is overridden', () => {
 			setCustomNomenclature({ entity: 'Group' });
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByText('Group Name')).toBeInTheDocument();
 			expect(screen.queryByText('Entity Name')).not.toBeInTheDocument();
 		});
 
 		it('renders custom save button label when entity is overridden', () => {
 			setCustomNomenclature({ entity: 'Group' });
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByRole('button', { name: /save group/i })).toBeInTheDocument();
 		});
 
 		it('renders custom placeholder when entity is overridden', () => {
 			setCustomNomenclature({ entity: 'Group' });
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByPlaceholderText('Name of this group...')).toBeInTheDocument();
 			expect(screen.getByPlaceholderText('Brief description of this group...')).toBeInTheDocument();
 		});
 
 		it('falls back to defaults when no custom nomenclature is set', () => {
-			render(EntityForm, { data: createData } as any);
+			renderEntityForm(createData);
 			expect(screen.getByText('Create Entity')).toBeInTheDocument();
 			expect(screen.getByText('Entity Name')).toBeInTheDocument();
 		});

--- a/src/routes/(admin)/entity/page.svelte.test.ts
+++ b/src/routes/(admin)/entity/page.svelte.test.ts
@@ -5,6 +5,7 @@ import EntityListingPage from './+page.svelte';
 import { canCreate, } from '$lib/utils/permissions.js';
 
 import { page } from '$app/state';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('$app/state', () => ({
 	page: {
@@ -34,6 +35,11 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	canUpdate: vi.fn(() => false),
 	canDelete: vi.fn(() => false)
 }));
+
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 vi.mock('$lib/components/data-table/BatchActionsToolbar.svelte', () => ({
 	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
@@ -87,6 +93,7 @@ describe('Entity Listing Page', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
 		(page as any).url = new URL('http://localhost/entity');
+		resetNomenclature();
 	});
 
 	
@@ -196,6 +203,47 @@ describe('Entity Listing Page', () => {
 		});
 	});
 
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Custom nomenclature labels', () => {
+		it('renders custom page title when entities is overridden', () => {
+			setCustomNomenclature({ entities: 'Groups' });
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.getByText('Groups')).toBeInTheDocument();
+			expect(screen.queryByText('Entities')).not.toBeInTheDocument();
+		});
 
-	
+		it('renders custom create button label when entity is overridden', () => {
+			setCustomNomenclature({ entity: 'Group' });
+			vi.mocked(canCreate).mockReturnValue(true);
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.getByRole('link', { name: /create group/i })).toBeInTheDocument();
+		});
+
+		it('renders custom empty state text when entities/entity are overridden', () => {
+			setCustomNomenclature({ entities: 'Groups', entity: 'Group' });
+			render(EntityListingPage, { data: makeData([]) } as any);
+			expect(screen.getByText('No groups yet')).toBeInTheDocument();
+			expect(screen.getByText(/Create your first group/i)).toBeInTheDocument();
+		});
+
+		it('renders custom search placeholder when entities is overridden', () => {
+			setCustomNomenclature({ entities: 'Groups' });
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.getByPlaceholderText('Search groups...')).toBeInTheDocument();
+		});
+
+		it('applies multiple custom nomenclature overrides simultaneously', () => {
+			setCustomNomenclature({ entities: 'Clusters', entity: 'Cluster' });
+			vi.mocked(canCreate).mockReturnValue(true);
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.getByText('Clusters')).toBeInTheDocument();
+			expect(screen.getByRole('link', { name: /create cluster/i })).toBeInTheDocument();
+			expect(screen.getByPlaceholderText('Search clusters...')).toBeInTheDocument();
+		});
+
+		it('falls back to defaults when no custom nomenclature is set', () => {
+			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			expect(screen.getByText('Entities')).toBeInTheDocument();
+		});
+	});
 });

--- a/src/routes/(admin)/entity/page.svelte.test.ts
+++ b/src/routes/(admin)/entity/page.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen, within } from '@testing-library/svelte';
+import type { ComponentProps } from 'svelte';
 import EntityListingPage from './+page.svelte';
 import { canCreate, } from '$lib/utils/permissions.js';
 
@@ -89,6 +90,10 @@ const sampleItems = [
 	{ id: 2, name: 'SHG', description: 'Self Help Group', modified_date: '2026-06-02', total_records: 3 }
 ];
 
+function renderEntityListingPage(data: ReturnType<typeof makeData>) {
+	return render(EntityListingPage, { data } as ComponentProps<typeof EntityListingPage>);
+}
+
 describe('Entity Listing Page', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
@@ -99,7 +104,7 @@ describe('Entity Listing Page', () => {
 	
 	describe('Page title', () => {
 		it('renders "Entities" as the page title', () => {
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.getByText('Entities')).toBeInTheDocument();
 		});
 	});
@@ -107,40 +112,40 @@ describe('Entity Listing Page', () => {
 
 	describe('Empty state', () => {
 		it('shows empty state heading when no items, no search, and no status filter', () => {
-			render(EntityListingPage, { data: makeData([]) } as any);
+			renderEntityListingPage(makeData([]));
 			expect(screen.getByText('No entities yet')).toBeInTheDocument();
 		});
 
 		it('shows descriptive text in the empty state', () => {
-			render(EntityListingPage, { data: makeData([]) } as any);
+			renderEntityListingPage(makeData([]));
 			expect(screen.getByText(/Create your first entity/i)).toBeInTheDocument();
 		});
 
 		it('shows "Create Entity" button inside empty state when user has create permission', () => {
 			vi.mocked(canCreate).mockReturnValue(true);
-			render(EntityListingPage, { data: makeData([]) } as any);
+			renderEntityListingPage(makeData([]));
 			const emptyStateRegion = screen.getByText('No entities yet').closest('div') as HTMLElement;
 			expect(within(emptyStateRegion).getByRole('link', { name: /create entity/i })).toBeInTheDocument();
 		});
 
 		it('does not show create button inside empty state when user lacks create permission', () => {
 			vi.mocked(canCreate).mockReturnValue(false);
-			render(EntityListingPage, { data: makeData([]) } as any);
+			renderEntityListingPage(makeData([]));
 			expect(screen.queryByRole('link', { name: /create entity/i })).not.toBeInTheDocument();
 		});
 
 		it('does not show empty state when items exist', () => {
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.queryByText('No entities yet')).not.toBeInTheDocument();
 		});
 
 		it('does not show empty state when search is set even with 0 results', () => {
-			render(EntityListingPage, { data: makeData([], { search: 'xyz' }) } as any);
+			renderEntityListingPage(makeData([], { search: 'xyz' }));
 			expect(screen.queryByText('No entities yet')).not.toBeInTheDocument();
 		});
 
 		it('does not show empty state when isActive filter is set even with 0 results', () => {
-			render(EntityListingPage, { data: makeData([], { isActive: 'true' }) } as any);
+			renderEntityListingPage(makeData([], { isActive: 'true' }));
 			expect(screen.queryByText('No entities yet')).not.toBeInTheDocument();
 		});
 	});
@@ -149,19 +154,19 @@ describe('Entity Listing Page', () => {
 	describe('Create button (header)', () => {
 		it('shows "Create Entity" header button when user has permission and items exist', () => {
 			vi.mocked(canCreate).mockReturnValue(true);
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.getByRole('link', { name: /create entity/i })).toBeInTheDocument();
 		});
 
 		it('does not show "Create Entity" header button when user lacks permission', () => {
 			vi.mocked(canCreate).mockReturnValue(false);
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.queryByRole('link', { name: /create entity/i })).not.toBeInTheDocument();
 		});
 
 		it('create button links to /entity/add/new', () => {
 			vi.mocked(canCreate).mockReturnValue(true);
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			const link = screen.getByRole('link', { name: /create entity/i });
 			expect(link).toHaveAttribute('href', '/entity/add/new');
 		});
@@ -170,17 +175,17 @@ describe('Entity Listing Page', () => {
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Search input', () => {
 		it('renders search input with placeholder "Search entities..."', () => {
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.getByPlaceholderText('Search entities...')).toBeInTheDocument();
 		});
 
 		it('reflects the current search value from params', () => {
-			render(EntityListingPage, { data: makeData(sampleItems, { search: 'CLF' }) } as any);
+			renderEntityListingPage(makeData(sampleItems, { search: 'CLF' }));
 			expect(screen.getByPlaceholderText('Search entities...')).toHaveValue('CLF');
 		});
 
 		it('shows empty value when search param is empty', () => {
-			render(EntityListingPage, { data: makeData(sampleItems, { search: '' }) } as any);
+			renderEntityListingPage(makeData(sampleItems, { search: '' }));
 			expect(screen.getByPlaceholderText('Search entities...')).toHaveValue('');
 		});
 	});
@@ -188,17 +193,17 @@ describe('Entity Listing Page', () => {
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Status filter', () => {
 		it('renders a "Status" button when no filter is active', () => {
-			render(EntityListingPage, { data: makeData(sampleItems, { isActive: '' }) } as any);
+			renderEntityListingPage(makeData(sampleItems, { isActive: '' }));
 			expect(screen.getByRole('button', { name: /status/i })).toBeInTheDocument();
 		});
 
 		it('renders "Active" label when isActive is "true"', () => {
-			render(EntityListingPage, { data: makeData(sampleItems, { isActive: 'true' }) } as any);
+			renderEntityListingPage(makeData(sampleItems, { isActive: 'true' }));
 			expect(screen.getByRole('button', { name: /active/i })).toBeInTheDocument();
 		});
 
 		it('renders "Inactive" label when isActive is "false"', () => {
-			render(EntityListingPage, { data: makeData(sampleItems, { isActive: 'false' }) } as any);
+			renderEntityListingPage(makeData(sampleItems, { isActive: 'false' }));
 			expect(screen.getByRole('button', { name: /inactive/i })).toBeInTheDocument();
 		});
 	});
@@ -207,7 +212,7 @@ describe('Entity Listing Page', () => {
 	describe('Custom nomenclature labels', () => {
 		it('renders custom page title when entities is overridden', () => {
 			setCustomNomenclature({ entities: 'Groups' });
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.getByText('Groups')).toBeInTheDocument();
 			expect(screen.queryByText('Entities')).not.toBeInTheDocument();
 		});
@@ -215,34 +220,34 @@ describe('Entity Listing Page', () => {
 		it('renders custom create button label when entity is overridden', () => {
 			setCustomNomenclature({ entity: 'Group' });
 			vi.mocked(canCreate).mockReturnValue(true);
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.getByRole('link', { name: /create group/i })).toBeInTheDocument();
 		});
 
 		it('renders custom empty state text when entities/entity are overridden', () => {
 			setCustomNomenclature({ entities: 'Groups', entity: 'Group' });
-			render(EntityListingPage, { data: makeData([]) } as any);
+			renderEntityListingPage(makeData([]));
 			expect(screen.getByText('No groups yet')).toBeInTheDocument();
 			expect(screen.getByText(/Create your first group/i)).toBeInTheDocument();
 		});
 
 		it('renders custom search placeholder when entities is overridden', () => {
 			setCustomNomenclature({ entities: 'Groups' });
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.getByPlaceholderText('Search groups...')).toBeInTheDocument();
 		});
 
 		it('applies multiple custom nomenclature overrides simultaneously', () => {
 			setCustomNomenclature({ entities: 'Clusters', entity: 'Cluster' });
 			vi.mocked(canCreate).mockReturnValue(true);
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.getByText('Clusters')).toBeInTheDocument();
 			expect(screen.getByRole('link', { name: /create cluster/i })).toBeInTheDocument();
 			expect(screen.getByPlaceholderText('Search clusters...')).toBeInTheDocument();
 		});
 
 		it('falls back to defaults when no custom nomenclature is set', () => {
-			render(EntityListingPage, { data: makeData(sampleItems) } as any);
+			renderEntityListingPage(makeData(sampleItems));
 			expect(screen.getByText('Entities')).toBeInTheDocument();
 		});
 	});

--- a/src/routes/(admin)/questionbank/import/page.svelte.test.ts
+++ b/src/routes/(admin)/questionbank/import/page.svelte.test.ts
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { writable } from 'svelte/store';
 import ImportQuestions from './+page.svelte';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 type MessageData = Record<string, unknown> | undefined;
 
@@ -12,6 +13,11 @@ let capturedOnUpdated: (() => void) | undefined;
 let formMessageStore = writable<MessageData>(undefined);
 
 const mockSubmit = vi.fn(() => capturedOnSubmit?.());
+
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 vi.mock('sveltekit-superforms', () => ({
 	fileProxy: () => ({
@@ -198,6 +204,39 @@ describe('Import Questions Page', () => {
 			expect(screen.getByText('10')).toBeInTheDocument();
 			expect(screen.getByText('8')).toBeInTheDocument();
 			expect(screen.getByText('2')).toBeInTheDocument();
+		});
+	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	describe('Custom nomenclature labels', () => {
+		beforeEach(() => {
+			resetNomenclature();
+		});
+
+		async function uploadAndComplete() {
+			render(ImportQuestions, { data: dataWithFile });
+			await fireEvent.click(screen.getByRole('button', { name: /import/i }));
+			await tick();
+			formMessageStore.set({
+				message: 'Done.',
+				uploaded_questions: 10,
+				success_questions: 10,
+				failed_questions: 0
+			});
+			capturedOnUpdated?.();
+			await tick();
+		}
+
+		it('renders custom "Go to" button label when question_bank is overridden', async () => {
+			setCustomNomenclature({ question_bank: 'Knowledge Base' });
+			await uploadAndComplete();
+			expect(screen.getByText('Go to Knowledge Base')).toBeInTheDocument();
+			expect(screen.queryByText('Go to Question Bank')).not.toBeInTheDocument();
+		});
+
+		it('renders default "Go to Question Bank" when no custom nomenclature is set', async () => {
+			await uploadAndComplete();
+			expect(screen.getByText('Go to Question Bank')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/routes/(admin)/questionbank/page.svelte.test.ts
+++ b/src/routes/(admin)/questionbank/page.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor, within } from '@testing-library/svelte';
 import QuestionListingPage from './+page.svelte';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('$app/state', () => ({
 	page: {
@@ -31,6 +32,11 @@ vi.mock('$app/forms', () => ({
 vi.mock('$lib/constants', () => ({
 	DEFAULT_PAGE_SIZE: 25
 }));
+
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 vi.mock('$lib/utils/permissions.js', () => ({
 	canCreate: vi.fn(() => false),
@@ -133,6 +139,7 @@ describe('Question Bank Listing Page', () => {
 		batchToolbarRef.props = null;
 		deleteDialogRef.props = null;
 		enhanceRef.submitFactory = null;
+		resetNomenclature();
 	});
 
 	// ────────────────────────────────────────────────────────────────────────
@@ -622,6 +629,21 @@ describe('Question Bank Listing Page', () => {
 		it('renders the TagsSelection filter', () => {
 			render(QuestionListingPage, { data: baseData([{ id: '1' }]) });
 			expect(mockTagsSelection).toHaveBeenCalled();
+		});
+	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	describe('Custom nomenclature labels', () => {
+		it('renders custom page title when question_bank is overridden', () => {
+			setCustomNomenclature({ question_bank: 'Knowledge Base' });
+			render(QuestionListingPage, { data: baseData([{ id: '1' }]) });
+			expect(screen.getByText('Knowledge Base')).toBeInTheDocument();
+			expect(screen.queryByText('Question Bank')).not.toBeInTheDocument();
+		});
+
+		it('falls back to default "Question Bank" when no custom nomenclature is set', () => {
+			render(QuestionListingPage, { data: baseData([{ id: '1' }]) });
+			expect(screen.getByText('Question Bank')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/questionbank/single-question/[action]/[id]/page.svelte.test.ts
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen, fireEvent, within } from '@testing-library/svelte';
 import SingleQuestionPage from './+page.svelte';
 import { QuestionTypeEnum } from '$lib/types/question';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('sveltekit-superforms/adapters', () => ({
 	zod4Client: vi.fn((schema: unknown) => schema)
@@ -25,6 +26,11 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	getUserState: vi.fn(() => null),
 	hasLocation: vi.fn(() => false)
 }));
+
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 const baseForm = {
 	question_text: '',
@@ -3037,5 +3043,38 @@ describe('Single Question Page - tag_type pre-population on edit', () => {
 		};
 		render(SingleQuestionPage, { data: { ...baseData, questionData } as any });
 		expect(screen.queryByText('Subject')).not.toBeInTheDocument();
+	});
+});
+
+describe('Single Question Page - Custom nomenclature labels', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetNomenclature();
+	});
+
+	it('renders custom tag_types label when nomenclature is overridden', () => {
+		setCustomNomenclature({ tag_types: 'Categories' });
+		render(SingleQuestionPage, { data: baseData as any });
+		expect(screen.getByText('Categories')).toBeInTheDocument();
+		expect(screen.queryByText('Tag Types')).not.toBeInTheDocument();
+	});
+
+	it('renders custom tags label when nomenclature is overridden', () => {
+		setCustomNomenclature({ tags: 'Labels' });
+		render(SingleQuestionPage, { data: baseData as any });
+		expect(screen.getByText('Labels')).toBeInTheDocument();
+	});
+
+	it('applies multiple custom nomenclature overrides simultaneously', () => {
+		setCustomNomenclature({ tag_types: 'Categories', tags: 'Labels' });
+		render(SingleQuestionPage, { data: baseData as any });
+		expect(screen.getByText('Categories')).toBeInTheDocument();
+		expect(screen.getByText('Labels')).toBeInTheDocument();
+	});
+
+	it('falls back to defaults when no custom nomenclature is set', () => {
+		render(SingleQuestionPage, { data: baseData as any });
+		expect(screen.getByText('Tag Types')).toBeInTheDocument();
+		expect(screen.getByText('Tags')).toBeInTheDocument();
 	});
 });

--- a/src/routes/(admin)/tags/page.svelte.test.ts
+++ b/src/routes/(admin)/tags/page.svelte.test.ts
@@ -4,29 +4,12 @@ import TagManagementPage from './+page.svelte';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
-const mockTermMap: Record<string, string> = {};
-
-vi.mock('$lib/nomenclature', () => ({
-	useTerms: () => (key: string, casing?: string) => {
-		const label = mockTermMap[key] ?? {
-			tag_management: 'Tag Management', tags: 'Tags', tag: 'Tag',
-			tag_types: 'Tag Types', tag_type: 'Tag Type'
-		}[key] ?? key;
-		if (casing === 'lower') return label.toLowerCase();
-		if (casing === 'upper') return label.toUpperCase();
-		return label;
-	}
-}));
-
-function setCustomNomenclature(overrides: Record<string, string>) {
-	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
-	Object.assign(mockTermMap, overrides);
-}
-
-function resetNomenclature() {
-	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
-}
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 const mockData = {
 	user: { id: 1, organization_id: 10, permissions: ['create_tag', 'update_tag', 'delete_tag'] },

--- a/src/routes/(admin)/tags/page.svelte.test.ts
+++ b/src/routes/(admin)/tags/page.svelte.test.ts
@@ -1,9 +1,32 @@
 import { render, fireEvent, screen } from '@testing-library/svelte';
 import '@testing-library/jest-dom/vitest';
 import TagManagementPage from './+page.svelte';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
+
+const mockTermMap: Record<string, string> = {};
+
+vi.mock('$lib/nomenclature', () => ({
+	useTerms: () => (key: string, casing?: string) => {
+		const label = mockTermMap[key] ?? {
+			tag_management: 'Tag Management', tags: 'Tags', tag: 'Tag',
+			tag_types: 'Tag Types', tag_type: 'Tag Type'
+		}[key] ?? key;
+		if (casing === 'lower') return label.toLowerCase();
+		if (casing === 'upper') return label.toUpperCase();
+		return label;
+	}
+}));
+
+function setCustomNomenclature(overrides: Record<string, string>) {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+	Object.assign(mockTermMap, overrides);
+}
+
+function resetNomenclature() {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+}
 
 const mockData = {
 	user: { id: 1, organization_id: 10, permissions: ['create_tag', 'update_tag', 'delete_tag'] },
@@ -217,6 +240,60 @@ describe('TagManagementPage', () => {
 			render(TagManagementPage, { data: mockData });
 			const nextButton = screen.getByText('Next');
 			expect(nextButton).toBeDisabled();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Custom nomenclature labels', () => {
+		afterEach(() => {
+			resetNomenclature();
+		});
+
+		it('renders custom page title when nomenclature overrides tag_management', () => {
+			setCustomNomenclature({ tag_management: 'Category Hub' });
+			render(TagManagementPage, { data: mockData });
+			expect(screen.getByRole('heading', { name: 'Category Hub' })).toBeInTheDocument();
+		});
+
+		it('renders custom create button label when tag_type is overridden', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			setCustomNomenclature({ tag_type: 'Topic' });
+			render(TagManagementPage, { data: mockData });
+			expect(screen.getByText(/Create Topic/)).toBeInTheDocument();
+		});
+
+		it('renders custom search placeholder with overridden labels', () => {
+			setCustomNomenclature({ tag_types: 'Topics', tags: 'Labels' });
+			render(TagManagementPage, { data: mockData });
+			expect(screen.getByPlaceholderText('Search topics or labels...')).toBeInTheDocument();
+		});
+
+		it('renders custom empty state text when tag_types is overridden', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			setCustomNomenclature({ tag_types: 'Topics', tag_type: 'Topic' });
+			render(TagManagementPage, { data: emptyMockData });
+			expect(screen.getByText('No topics yet')).toBeInTheDocument();
+		});
+
+		it('renders custom column header when tag_types is overridden', () => {
+			setCustomNomenclature({ tag_types: 'Categories' });
+			render(TagManagementPage, { data: mockData });
+			const sortButton = screen.getByText('Categories').closest('button');
+			expect(sortButton).toBeTruthy();
+		});
+
+		it('applies multiple custom nomenclature overrides together', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			setCustomNomenclature({
+				tag_management: 'Label Centre',
+				tag_type: 'Category',
+				tag_types: 'Categories',
+				tags: 'Labels'
+			});
+			render(TagManagementPage, { data: mockData });
+			expect(screen.getByRole('heading', { name: 'Label Centre' })).toBeInTheDocument();
+			expect(screen.getByText(/Create Category/)).toBeInTheDocument();
+			expect(screen.getByPlaceholderText('Search categories or labels...')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/svelte';
 import { get, writable } from 'svelte/store';
 import TestCreatePage from './+page.svelte';
 import { superForm } from 'sveltekit-superforms';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
 
@@ -40,6 +41,11 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	getUserState: vi.fn(() => null),
 	getUserDistrict: vi.fn(() => null)
 }));
+
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -131,6 +137,7 @@ describe('Test Create/Update Page', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		setupSuperFormMock();
+		resetNomenclature();
 	});
 
 	// ── Step header ───────────────────────────────────────────────────────────
@@ -698,6 +705,65 @@ describe('Test Create/Update Page', () => {
 
 			// Still intact after returning to step 1
 			expect(get(formStore).tag_type_ids).toEqual([{ id: '10', name: 'Subject' }]);
+		});
+	});
+
+	// ── Custom nomenclature labels ───────────────────────────────────────────
+
+	describe('Custom nomenclature labels', () => {
+		it('renders custom heading for session mode when test is overridden', () => {
+			setCustomNomenclature({ test: 'Exam' });
+			setupSuperFormMock();
+			render(TestCreatePage, { data: baseData() });
+			expect(screen.getByText('Create Exam')).toBeInTheDocument();
+			expect(screen.queryByText('Create Test')).not.toBeInTheDocument();
+		});
+
+		it('renders custom heading for template mode when test_template is overridden', () => {
+			setCustomNomenclature({ test_template: 'Exam Blueprint' });
+			setupSuperFormMock({ is_template: true });
+			render(TestCreatePage, { data: baseData({ convertTemplate: false }) });
+			expect(screen.getByText('Create Exam Blueprint')).toBeInTheDocument();
+		});
+
+		it('renders custom step label for test configuration when test is overridden', () => {
+			setCustomNomenclature({ test: 'Assessment' });
+			setupSuperFormMock();
+			render(TestCreatePage, { data: baseData() });
+			expect(screen.getByText('Assessment Configuration')).toBeInTheDocument();
+			expect(screen.queryByText('Test Configuration')).not.toBeInTheDocument();
+		});
+
+		it('renders custom edit heading when test is overridden and testData is present', () => {
+			setCustomNomenclature({ test: 'Quiz' });
+			setupSuperFormMock();
+			const testData = {
+				id: '42',
+				name: 'Existing',
+				description: '',
+				question_revisions: [],
+				question_sets: [],
+				states: [],
+				districts: [],
+				tags: [],
+				random_tag_counts: []
+			};
+			render(TestCreatePage, { data: baseData({ testData }) });
+			expect(screen.getByText('Edit Quiz')).toBeInTheDocument();
+		});
+
+		it('renders custom select template step label when test_template is overridden', () => {
+			setCustomNomenclature({ test_template: 'Exam Blueprint' });
+			setupSuperFormMock();
+			render(TestCreatePage, { data: baseData({ convertTemplate: true }) });
+			expect(screen.getByText('Select Exam Blueprint')).toBeInTheDocument();
+		});
+
+		it('falls back to defaults when no custom nomenclature is set', () => {
+			setupSuperFormMock();
+			render(TestCreatePage, { data: baseData() });
+			expect(screen.getByText('Create Test')).toBeInTheDocument();
+			expect(screen.getByText('Test Configuration')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import TestListingPage from './+page.svelte';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('$app/state', () => ({
 	page: {
@@ -37,29 +38,10 @@ vi.mock('$lib/components/data-table/BatchActionsToolbar.svelte', () => ({
 	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
 }));
 
-const mockTermMap: Record<string, string> = {};
-
-vi.mock('$lib/nomenclature', () => ({
-	useTerms: () => (key: string, casing?: string) => {
-		const label = mockTermMap[key] ?? {
-			tests: 'Tests', test: 'Test', test_templates: 'Test Templates',
-			test_template: 'Test Template', tags: 'Tags', tag: 'Tag',
-			tag_types: 'Tag Types', tag_type: 'Tag Type'
-		}[key] ?? key;
-		if (casing === 'lower') return label.toLowerCase();
-		if (casing === 'upper') return label.toUpperCase();
-		return label;
-	}
-}));
-
-function setCustomNomenclature(overrides: Record<string, string>) {
-	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
-	Object.assign(mockTermMap, overrides);
-}
-
-function resetNomenclature() {
-	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
-}
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 vi.mock('$lib/components/data-table/index.js', () => ({
 	// The DataTable mock must read `columns` from its props so Svelte 5 evaluates

--- a/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/page.svelte.test.ts
@@ -37,6 +37,30 @@ vi.mock('$lib/components/data-table/BatchActionsToolbar.svelte', () => ({
 	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
 }));
 
+const mockTermMap: Record<string, string> = {};
+
+vi.mock('$lib/nomenclature', () => ({
+	useTerms: () => (key: string, casing?: string) => {
+		const label = mockTermMap[key] ?? {
+			tests: 'Tests', test: 'Test', test_templates: 'Test Templates',
+			test_template: 'Test Template', tags: 'Tags', tag: 'Tag',
+			tag_types: 'Tag Types', tag_type: 'Tag Type'
+		}[key] ?? key;
+		if (casing === 'lower') return label.toLowerCase();
+		if (casing === 'upper') return label.toUpperCase();
+		return label;
+	}
+}));
+
+function setCustomNomenclature(overrides: Record<string, string>) {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+	Object.assign(mockTermMap, overrides);
+}
+
+function resetNomenclature() {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+}
+
 vi.mock('$lib/components/data-table/index.js', () => ({
 	// The DataTable mock must read `columns` from its props so Svelte 5 evaluates
 	// the lazy $derived(columns) — which is the only trigger for createTestColumns.
@@ -590,6 +614,70 @@ describe('Test Management Listing Page', () => {
 		it('passes enableSelection=true when user can delete test templates and templates exist', async () => {
 			await renderAndCapture(true, true);
 			expect(sortRef.enableSelection).toBe(true);
+		});
+	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	describe('Custom nomenclature labels', () => {
+		afterEach(() => {
+			resetNomenclature();
+		});
+
+		it('renders custom title for session mode when nomenclature overrides tests', () => {
+			setCustomNomenclature({ tests: 'Assessments', test: 'Assessment' });
+			render(TestListingPage, { data: baseData(false) });
+			expect(screen.getByText('Assessments')).toBeInTheDocument();
+			expect(screen.queryByText('Tests')).not.toBeInTheDocument();
+		});
+
+		it('renders custom title for template mode when nomenclature overrides test_templates', () => {
+			setCustomNomenclature({ test_templates: 'Exam Blueprints', test_template: 'Exam Blueprint' });
+			render(TestListingPage, { data: baseData(true) });
+			expect(screen.getByText('Exam Blueprints')).toBeInTheDocument();
+			expect(screen.queryByText('Test Templates')).not.toBeInTheDocument();
+		});
+
+		it('renders custom search placeholder for session mode', () => {
+			setCustomNomenclature({ tests: 'Assessments' });
+			const items = [{ id: '1', name: 'Test A' }];
+			render(TestListingPage, { data: baseData(false, items) });
+			expect(screen.getByPlaceholderText('Search assessments...')).toBeInTheDocument();
+		});
+
+		it('renders custom search placeholder for template mode', () => {
+			setCustomNomenclature({ test_templates: 'Exam Blueprints' });
+			const items = [{ id: '1', name: 'Template A' }];
+			render(TestListingPage, { data: baseData(true, items) });
+			expect(screen.getByPlaceholderText('Search exam blueprints...')).toBeInTheDocument();
+		});
+
+		it('renders custom empty state text for template mode', () => {
+			setCustomNomenclature({ test_templates: 'Exam Blueprints', test_template: 'Exam Blueprint' });
+			render(TestListingPage, { data: baseData(true, []) });
+			expect(screen.getByText('No exam blueprints yet')).toBeInTheDocument();
+		});
+
+		it('renders custom empty state text for session mode', () => {
+			setCustomNomenclature({ test: 'Assessment' });
+			render(TestListingPage, { data: baseData(false, []) });
+			expect(screen.getByText('Create your first assessment')).toBeInTheDocument();
+		});
+
+		it('renders custom create button text for templates', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			setCustomNomenclature({ test_template: 'Exam Blueprint' });
+			const items = [{ id: '1', name: 'Template A' }];
+			render(TestListingPage, { data: baseData(true, items) });
+			expect(screen.getByText('Create Exam Blueprint')).toBeInTheDocument();
+		});
+
+		it('renders custom "Create New" text when user cannot read test templates', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			vi.mocked(canRead).mockReturnValue(false);
+			setCustomNomenclature({ test: 'Assessment' });
+			const items = [{ id: '1', name: 'Session A' }];
+			render(TestListingPage, { data: baseData(false, items) });
+			expect(screen.getByText('Create New Assessment')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/routes/(admin)/users/page.svelte.test.ts
+++ b/src/routes/(admin)/users/page.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import UsersListingPage from './+page.svelte';
@@ -35,9 +35,25 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	canDelete: vi.fn(() => false)
 }));
 
+const mockTermMap: Record<string, string> = {};
+
 vi.mock('$lib/nomenclature', () => ({
-	useTerms: () => (key: string) => key
+	useTerms: () => (key: string, casing?: string) => {
+		const label = mockTermMap[key] ?? { users: 'Users', user: 'User' }[key] ?? key;
+		if (casing === 'lower') return label.toLowerCase();
+		if (casing === 'upper') return label.toUpperCase();
+		return label;
+	}
 }));
+
+function setCustomNomenclature(overrides: Record<string, string>) {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+	Object.assign(mockTermMap, overrides);
+}
+
+function resetNomenclature() {
+	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
+}
 
 vi.mock('$lib/components/data-table/BatchActionsToolbar.svelte', () => ({
 	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))
@@ -95,9 +111,9 @@ describe('Users Listing Page', () => {
 
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Page title', () => {
-		it('renders "users" as the page title', () => {
+		it('renders "Users" as the page title', () => {
 			render(UsersListingPage, { data: makeData() } as any);
-			expect(screen.getByText('users')).toBeInTheDocument();
+			expect(screen.getByText('Users')).toBeInTheDocument();
 		});
 	});
 
@@ -225,7 +241,7 @@ describe('Users Listing Page', () => {
 	describe('Empty state', () => {
 		it('renders without error when users list is empty', () => {
 			render(UsersListingPage, { data: makeData([]) } as any);
-			expect(screen.getByText('users')).toBeInTheDocument();
+			expect(screen.getByText('Users')).toBeInTheDocument();
 		});
 
 		it('does not show user data when items list is empty', () => {
@@ -281,6 +297,42 @@ describe('Users Listing Page', () => {
 			vi.mocked(canDelete).mockReturnValue(true);
 			render(UsersListingPage, { data: makeData() } as any);
 			expect(canDelete).toHaveBeenCalledWith(expect.anything(), 'user');
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Custom nomenclature labels', () => {
+		afterEach(() => {
+			resetNomenclature();
+		});
+
+		it('renders custom page title when nomenclature overrides users', () => {
+			setCustomNomenclature({ users: 'Members', user: 'Member' });
+			render(UsersListingPage, { data: makeData() } as any);
+			expect(screen.getByText('Members')).toBeInTheDocument();
+			expect(screen.queryByText('Users')).not.toBeInTheDocument();
+		});
+
+		it('renders custom create button label', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			setCustomNomenclature({ user: 'Participant' });
+			render(UsersListingPage, { data: makeData() } as any);
+			expect(screen.getByRole('link', { name: /create participant/i })).toBeInTheDocument();
+		});
+
+		it('renders custom search placeholder', () => {
+			setCustomNomenclature({ users: 'Learners' });
+			render(UsersListingPage, { data: makeData() } as any);
+			expect(screen.getByPlaceholderText('Search learners...')).toBeInTheDocument();
+		});
+
+		it('applies multiple custom nomenclature overrides together', () => {
+			vi.mocked(canCreate).mockReturnValue(true);
+			setCustomNomenclature({ users: 'Participants', user: 'Participant' });
+			render(UsersListingPage, { data: makeData() } as any);
+			expect(screen.getByText('Participants')).toBeInTheDocument();
+			expect(screen.getByRole('link', { name: /create participant/i })).toBeInTheDocument();
+			expect(screen.getByPlaceholderText('Search participants...')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/routes/(admin)/users/page.svelte.test.ts
+++ b/src/routes/(admin)/users/page.svelte.test.ts
@@ -5,6 +5,7 @@ import UsersListingPage from './+page.svelte';
 import { canCreate, canUpdate, canDelete } from '$lib/utils/permissions.js';
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
+import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('$app/navigation', () => ({
 	goto: vi.fn(),
@@ -35,25 +36,10 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	canDelete: vi.fn(() => false)
 }));
 
-const mockTermMap: Record<string, string> = {};
-
-vi.mock('$lib/nomenclature', () => ({
-	useTerms: () => (key: string, casing?: string) => {
-		const label = mockTermMap[key] ?? { users: 'Users', user: 'User' }[key] ?? key;
-		if (casing === 'lower') return label.toLowerCase();
-		if (casing === 'upper') return label.toUpperCase();
-		return label;
-	}
-}));
-
-function setCustomNomenclature(overrides: Record<string, string>) {
-	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
-	Object.assign(mockTermMap, overrides);
-}
-
-function resetNomenclature() {
-	Object.keys(mockTermMap).forEach((k) => delete mockTermMap[k]);
-}
+vi.mock('$lib/nomenclature', async () => {
+	const { createNomenclatureMock } = await import('$lib/test-utils/nomenclature-mock');
+	return createNomenclatureMock();
+});
 
 vi.mock('$lib/components/data-table/BatchActionsToolbar.svelte', () => ({
 	default: vi.fn().mockImplementation(() => ({ $$set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() }))


### PR DESCRIPTION
fixes: #539 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broader test coverage for custom nomenclature labels across multiple admin areas (Dashboard, Tag Management, Tests, Users, Question Bank, Entity/Certificate flows, and supporting sidebar UI).
  * Introduced a shared nomenclature mock utility with per-test override control to ensure custom terms render reliably.
  * Validated simultaneous overrides and confirmed labels revert to defaults after each test.
  * Updated/expanded UI assertions for headings, buttons, placeholders, empty states, and navigation text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->