### PR TITLE
add coverage for organization details

### DIFF
--- a/src/lib/components/app-sidebar.svelte.test.ts
+++ b/src/lib/components/app-sidebar.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import AppSidebar from './app-sidebar.svelte';
+import { isSuperAdmin } from '$lib/utils/permissions.js';
 import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('$app/navigation', () => ({
@@ -161,5 +162,137 @@ describe('AppSidebar - Custom nomenclature labels', () => {
 		render(AppSidebar, { data: baseData });
 		expect(screen.getByText('Tests')).toBeInTheDocument();
 		expect(screen.getByText('Question Bank')).toBeInTheDocument();
+	});
+});
+
+describe('AppSidebar - Analytics Link', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(isSuperAdmin).mockReturnValue(false);
+	});
+
+	it('should show Analytics menu item when analyticsLinkUrl is provided', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				analyticsLinkUrl: 'https://lookerstudio.google.com/test'
+			}
+		});
+
+		expect(screen.getByText('Analytics')).toBeInTheDocument();
+	});
+
+	it('should link Analytics to the correct URL', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				analyticsLinkUrl: 'https://lookerstudio.google.com/test'
+			}
+		});
+
+		const link = screen.getByText('Analytics').closest('a');
+		expect(link).toHaveAttribute('href', 'https://lookerstudio.google.com/test');
+	});
+
+	it('should open Analytics link in a new tab', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				analyticsLinkUrl: 'https://lookerstudio.google.com/test'
+			}
+		});
+
+		const link = screen.getByText('Analytics').closest('a');
+		expect(link).toHaveAttribute('target', '_blank');
+	});
+
+	it('should not show Analytics menu item when analyticsLinkUrl is null', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				analyticsLinkUrl: null
+			}
+		});
+
+		expect(screen.queryByText('Analytics')).not.toBeInTheDocument();
+	});
+
+	it('should not show Analytics menu item when user is superAdmin', () => {
+		vi.mocked(isSuperAdmin).mockReturnValue(true);
+
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				analyticsLinkUrl: 'https://lookerstudio.google.com/test'
+			}
+		});
+
+		expect(screen.queryByText('Analytics')).not.toBeInTheDocument();
+	});
+});
+
+describe('AppSidebar - Platform Guide PDF', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(isSuperAdmin).mockReturnValue(false);
+	});
+
+	it('should show Platform Guide PDF link when platformGuideUrl is provided', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				platformGuideUrl: 'https://cdn.example.com/guide.pdf'
+			}
+		});
+
+		expect(screen.getByText('Platform Guide PDF')).toBeInTheDocument();
+	});
+
+	it('should link Platform Guide PDF to the correct URL', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				platformGuideUrl: 'https://cdn.example.com/guide.pdf'
+			}
+		});
+
+		const link = screen.getByText('Platform Guide PDF').closest('a');
+		expect(link).toHaveAttribute('href', 'https://cdn.example.com/guide.pdf');
+	});
+
+	it('should open Platform Guide PDF link in a new tab', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				platformGuideUrl: 'https://cdn.example.com/guide.pdf'
+			}
+		});
+
+		const link = screen.getByText('Platform Guide PDF').closest('a');
+		expect(link).toHaveAttribute('target', '_blank');
+	});
+
+	it('should not show Platform Guide PDF link when platformGuideUrl is null', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				platformGuideUrl: null
+			}
+		});
+
+		expect(screen.queryByText('Platform Guide PDF')).not.toBeInTheDocument();
+	});
+
+	it('should not show Platform Guide PDF link when user is superAdmin', () => {
+		vi.mocked(isSuperAdmin).mockReturnValue(true);
+
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				platformGuideUrl: 'https://cdn.example.com/guide.pdf'
+			}
+		});
+
+		expect(screen.queryByText('Platform Guide PDF')).not.toBeInTheDocument();
 	});
 });

--- a/src/lib/components/app-sidebar.svelte.test.ts
+++ b/src/lib/components/app-sidebar.svelte.test.ts
@@ -93,6 +93,55 @@ describe('AppSidebar - Organization Branding', () => {
 		expect(screen.queryByText('Sashakt')).not.toBeInTheDocument();
 		expect(screen.queryByText('Acme Corp')).not.toBeInTheDocument();
 	});
+
+	it('should show org logo in sidebar after login when org has shortcode and logo configured', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				organization: {
+					name: 'XYZ Org',
+					logo: 'https://cdn.example.com/xyz-logo.png',
+					shortcode: 'xyz'
+				}
+			}
+		});
+
+		const img = screen.getByRole('img');
+		expect(img).toBeInTheDocument();
+		expect(img).toHaveAttribute('src', 'https://cdn.example.com/xyz-logo.png');
+		expect(img).toHaveAttribute('alt', 'XYZ Org');
+	});
+
+	it('should not show "Sashakt" in sidebar after login when org has shortcode and logo configured', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				organization: {
+					name: 'XYZ Org',
+					logo: 'https://cdn.example.com/xyz-logo.png',
+					shortcode: 'xyz'
+				}
+			}
+		});
+
+		expect(screen.queryByText('Sashakt')).not.toBeInTheDocument();
+	});
+
+	it('should show "Sashakt" in sidebar after login when org has shortcode but no logo configured', () => {
+		render(AppSidebar, {
+			data: {
+				...baseData,
+				organization: {
+					name: 'XYZ Org',
+					logo: '',
+					shortcode: 'xyz'
+				}
+			}
+		});
+
+		expect(screen.getByText('Sashakt')).toBeInTheDocument();
+		expect(screen.queryByRole('img')).not.toBeInTheDocument();
+	});
 });
 
 describe('AppSidebar - Custom nomenclature labels', () => {

--- a/src/lib/server/organization-layout-settings.test.ts
+++ b/src/lib/server/organization-layout-settings.test.ts
@@ -102,42 +102,4 @@ describe('loadOrganizationLayoutSettings', () => {
 		expect(result.analyticsLinkUrl).toBeNull();
 		expect(result.platformGuideUrl).toBeNull();
 	});
-
-	it('should parse platform nomenclature with custom mode', async () => {
-		mockFetch.mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({
-				settings: {
-					platform_nomenclature: {
-						mode: 'custom',
-						value: { tests: 'Exams', users: 'Participants' }
-					}
-				}
-			})
-		});
-
-		const result = await loadOrganizationLayoutSettings(42, mockFetch);
-
-		expect(result.platformNomenclature.mode).toBe('custom');
-		expect(result.platformNomenclature.value.tests).toBe('Exams');
-		expect(result.platformNomenclature.value.users).toBe('Participants');
-	});
-
-	it('should default nomenclature mode when mode is not custom', async () => {
-		mockFetch.mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({
-				settings: {
-					platform_nomenclature: {
-						mode: 'something_else',
-						value: {}
-					}
-				}
-			})
-		});
-
-		const result = await loadOrganizationLayoutSettings(42, mockFetch);
-
-		expect(result.platformNomenclature.mode).toBe('default');
-	});
 });

--- a/src/lib/server/organization-layout-settings.test.ts
+++ b/src/lib/server/organization-layout-settings.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadOrganizationLayoutSettings } from './organization-layout-settings';
+
+vi.mock('$env/static/private', () => ({
+	BACKEND_URL: 'http://localhost:8000'
+}));
+
+vi.mock('./auth', () => ({
+	getSessionTokenCookie: vi.fn(() => 'mock-token')
+}));
+
+describe('loadOrganizationLayoutSettings', () => {
+	const mockFetch = vi.fn();
+
+	beforeEach(() => {
+		mockFetch.mockReset();
+	});
+
+	it('should return analytics and platform guide URLs from settings', async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				settings: {
+					analytics_link: { value: { url: 'https://lookerstudio.google.com/abc' } },
+					platform_guide: { value: { file_path: 'https://cdn.example.com/guide.pdf' } }
+				}
+			})
+		});
+
+		const result = await loadOrganizationLayoutSettings(42, mockFetch);
+
+		expect(result.analyticsLinkUrl).toBe('https://lookerstudio.google.com/abc');
+		expect(result.platformGuideUrl).toBe('https://cdn.example.com/guide.pdf');
+	});
+
+	it('should call the correct API endpoint with bearer token', async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ settings: {} })
+		});
+
+		await loadOrganizationLayoutSettings(99, mockFetch);
+
+		expect(mockFetch).toHaveBeenCalledWith(
+			'http://localhost:8000/organization/99/settings',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					Authorization: 'Bearer mock-token'
+				})
+			})
+		);
+	});
+
+	it('should return null URLs when settings has no analytics or platform guide', async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				settings: {
+					some_other_setting: { value: 'test' }
+				}
+			})
+		});
+
+		const result = await loadOrganizationLayoutSettings(42, mockFetch);
+
+		expect(result.analyticsLinkUrl).toBeNull();
+		expect(result.platformGuideUrl).toBeNull();
+	});
+
+	it('should return fallback when API returns non-ok response', async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: false,
+			status: 500
+		});
+
+		const result = await loadOrganizationLayoutSettings(42, mockFetch);
+
+		expect(result.analyticsLinkUrl).toBeNull();
+		expect(result.platformGuideUrl).toBeNull();
+		expect(result.platformNomenclature.mode).toBe('default');
+	});
+
+	it('should return fallback when fetch throws', async () => {
+		mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+		const result = await loadOrganizationLayoutSettings(42, mockFetch);
+
+		expect(result.analyticsLinkUrl).toBeNull();
+		expect(result.platformGuideUrl).toBeNull();
+		expect(result.platformNomenclature.mode).toBe('default');
+	});
+
+	it('should return fallback when settings is null in response body', async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ settings: null })
+		});
+
+		const result = await loadOrganizationLayoutSettings(42, mockFetch);
+
+		expect(result.analyticsLinkUrl).toBeNull();
+		expect(result.platformGuideUrl).toBeNull();
+	});
+
+	it('should parse platform nomenclature with custom mode', async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				settings: {
+					platform_nomenclature: {
+						mode: 'custom',
+						value: { tests: 'Exams', users: 'Participants' }
+					}
+				}
+			})
+		});
+
+		const result = await loadOrganizationLayoutSettings(42, mockFetch);
+
+		expect(result.platformNomenclature.mode).toBe('custom');
+		expect(result.platformNomenclature.value.tests).toBe('Exams');
+		expect(result.platformNomenclature.value.users).toBe('Participants');
+	});
+
+	it('should default nomenclature mode when mode is not custom', async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				settings: {
+					platform_nomenclature: {
+						mode: 'something_else',
+						value: {}
+					}
+				}
+			})
+		});
+
+		const result = await loadOrganizationLayoutSettings(42, mockFetch);
+
+		expect(result.platformNomenclature.mode).toBe('default');
+	});
+});

--- a/src/routes/(admin)/layout.server.test.ts
+++ b/src/routes/(admin)/layout.server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { load } from './+layout.server';
 import { loadOrganizationLayoutSettings } from '$lib/server/organization-layout-settings';
+import { getRequestEvent } from '$app/server';
 
 vi.mock('$env/static/private', () => ({
 	BACKEND_URL: 'http://localhost:8000'
@@ -18,8 +19,6 @@ vi.mock('$app/server', () => ({
 vi.mock('$lib/server/organization-layout-settings', () => ({
 	loadOrganizationLayoutSettings: vi.fn()
 }));
-
-const { getRequestEvent } = await import('$app/server');
 
 describe('Admin Layout Server - load()', () => {
 	const mockFetch = vi.fn();
@@ -81,7 +80,11 @@ describe('Admin Layout Server - load()', () => {
 
 	it('should pass user and organization from locals to the result', async () => {
 		const mockUser = { organization_id: 10, permissions: ['read_test'] };
-		const mockOrganization = { name: 'Acme', shortcode: 'acme', logo: 'https://example.com/logo.png' };
+		const mockOrganization = {
+			name: 'Acme',
+			shortcode: 'acme',
+			logo: 'https://example.com/logo.png'
+		};
 
 		vi.mocked(getRequestEvent).mockReturnValue({
 			locals: {

--- a/src/routes/(admin)/layout.server.test.ts
+++ b/src/routes/(admin)/layout.server.test.ts
@@ -104,28 +104,4 @@ describe('Admin Layout Server - load()', () => {
 		expect(result.user).toBe(mockUser);
 		expect(result.organization).toBe(mockOrganization);
 	});
-
-	it('should return platformNomenclature from org settings', async () => {
-		const customNomenclature = {
-			mode: 'custom' as const,
-			value: { tests: 'Exams', users: 'Participants' } as any
-		};
-
-		vi.mocked(getRequestEvent).mockReturnValue({
-			locals: {
-				user: { organization_id: 42, permissions: [] },
-				organization: null
-			}
-		} as any);
-
-		vi.mocked(loadOrganizationLayoutSettings).mockResolvedValue({
-			platformNomenclature: customNomenclature,
-			platformGuideUrl: null,
-			analyticsLinkUrl: null
-		});
-
-		const result = await load({ fetch: mockFetch } as any);
-
-		expect(result.platformNomenclature).toBe(customNomenclature);
-	});
 });

--- a/src/routes/(admin)/layout.server.test.ts
+++ b/src/routes/(admin)/layout.server.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { load } from './+layout.server';
+import { loadOrganizationLayoutSettings } from '$lib/server/organization-layout-settings';
+
+vi.mock('$env/static/private', () => ({
+	BACKEND_URL: 'http://localhost:8000'
+}));
+
+vi.mock('$app/server', () => ({
+	getRequestEvent: vi.fn(() => ({
+		locals: {
+			user: null,
+			organization: null
+		}
+	}))
+}));
+
+vi.mock('$lib/server/organization-layout-settings', () => ({
+	loadOrganizationLayoutSettings: vi.fn()
+}));
+
+const { getRequestEvent } = await import('$app/server');
+
+describe('Admin Layout Server - load()', () => {
+	const mockFetch = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should return analyticsLinkUrl and platformGuideUrl from org settings when user has organization_id', async () => {
+		vi.mocked(getRequestEvent).mockReturnValue({
+			locals: {
+				user: { organization_id: 42, permissions: [] },
+				organization: { name: 'Test Org', shortcode: 'test' }
+			}
+		} as any);
+
+		vi.mocked(loadOrganizationLayoutSettings).mockResolvedValue({
+			platformNomenclature: { mode: 'default', value: {} as any },
+			platformGuideUrl: 'https://cdn.example.com/guide.pdf',
+			analyticsLinkUrl: 'https://lookerstudio.google.com/abc'
+		});
+
+		const result = await load({ fetch: mockFetch } as any);
+
+		expect(loadOrganizationLayoutSettings).toHaveBeenCalledWith(42, mockFetch);
+		expect(result.analyticsLinkUrl).toBe('https://lookerstudio.google.com/abc');
+		expect(result.platformGuideUrl).toBe('https://cdn.example.com/guide.pdf');
+	});
+
+	it('should return null for analyticsLinkUrl and platformGuideUrl when user has no organization_id', async () => {
+		vi.mocked(getRequestEvent).mockReturnValue({
+			locals: {
+				user: { permissions: [] },
+				organization: null
+			}
+		} as any);
+
+		const result = await load({ fetch: mockFetch } as any);
+
+		expect(loadOrganizationLayoutSettings).not.toHaveBeenCalled();
+		expect(result.analyticsLinkUrl).toBeNull();
+		expect(result.platformGuideUrl).toBeNull();
+	});
+
+	it('should return null when user is null', async () => {
+		vi.mocked(getRequestEvent).mockReturnValue({
+			locals: {
+				user: null,
+				organization: null
+			}
+		} as any);
+
+		const result = await load({ fetch: mockFetch } as any);
+
+		expect(loadOrganizationLayoutSettings).not.toHaveBeenCalled();
+		expect(result.analyticsLinkUrl).toBeNull();
+		expect(result.platformGuideUrl).toBeNull();
+	});
+
+	it('should pass user and organization from locals to the result', async () => {
+		const mockUser = { organization_id: 10, permissions: ['read_test'] };
+		const mockOrganization = { name: 'Acme', shortcode: 'acme', logo: 'https://example.com/logo.png' };
+
+		vi.mocked(getRequestEvent).mockReturnValue({
+			locals: {
+				user: mockUser,
+				organization: mockOrganization
+			}
+		} as any);
+
+		vi.mocked(loadOrganizationLayoutSettings).mockResolvedValue({
+			platformNomenclature: { mode: 'default', value: {} as any },
+			platformGuideUrl: null,
+			analyticsLinkUrl: null
+		});
+
+		const result = await load({ fetch: mockFetch } as any);
+
+		expect(result.user).toBe(mockUser);
+		expect(result.organization).toBe(mockOrganization);
+	});
+
+	it('should return platformNomenclature from org settings', async () => {
+		const customNomenclature = {
+			mode: 'custom' as const,
+			value: { tests: 'Exams', users: 'Participants' } as any
+		};
+
+		vi.mocked(getRequestEvent).mockReturnValue({
+			locals: {
+				user: { organization_id: 42, permissions: [] },
+				organization: null
+			}
+		} as any);
+
+		vi.mocked(loadOrganizationLayoutSettings).mockResolvedValue({
+			platformNomenclature: customNomenclature,
+			platformGuideUrl: null,
+			analyticsLinkUrl: null
+		});
+
+		const result = await load({ fetch: mockFetch } as any);
+
+		expect(result.platformNomenclature).toBe(customNomenclature);
+	});
+});

--- a/src/routes/login/page.server.test.ts
+++ b/src/routes/login/page.server.test.ts
@@ -148,6 +148,63 @@ describe('Login Route', () => {
 			expect(result.organizationData).toEqual(orgData);
 			expect(orgFetch).not.toHaveBeenCalled();
 		});
+
+		it('returns both shortcode and logo when org is fully configured', async () => {
+			const orgFetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					name: 'XYZ Org',
+					logo: 'https://cdn.example.com/xyz-logo.png',
+					shortcode: 'xyz'
+				})
+			});
+
+			const result = await load(
+				makeLoadEvent({
+					url: new URL('http://localhost/login?organization=xyz'),
+					fetch: orgFetch
+				})
+			);
+
+			expect(result.organizationData).toMatchObject({
+				shortcode: 'xyz',
+				logo: 'https://cdn.example.com/xyz-logo.png',
+				name: 'XYZ Org'
+			});
+		});
+
+		it('fetches from public endpoint using the shortcode from the URL param', async () => {
+			const orgFetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ name: 'XYZ Org', logo: 'logo.png', shortcode: 'xyz' })
+			});
+
+			await load(
+				makeLoadEvent({
+					url: new URL('http://localhost/login?organization=xyz'),
+					fetch: orgFetch
+				})
+			);
+
+			expect(orgFetch).toHaveBeenCalledWith('http://localhost:8000/organization/public/xyz');
+		});
+
+		it('returns null logo in organizationData when org has shortcode but no logo', async () => {
+			const orgFetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ name: 'XYZ Org', logo: null, shortcode: 'xyz' })
+			});
+
+			const result = await load(
+				makeLoadEvent({
+					url: new URL('http://localhost/login?organization=xyz'),
+					fetch: orgFetch
+				})
+			);
+
+			expect(result.organizationData?.shortcode).toBe('xyz');
+			expect(result.organizationData?.logo).toBeFalsy();
+		});
 	});
 
 	describe('actions.login — form validation', () => {

--- a/src/routes/login/page.svelte.test.ts
+++ b/src/routes/login/page.svelte.test.ts
@@ -113,6 +113,39 @@ describe('Login Page', () => {
 			});
 			expect(screen.getByAltText('Tech4Dev')).toBeInTheDocument();
 		});
+
+		it('should show logo when organization has both shortcode and logo configured', () => {
+			render(LoginPage, {
+				data: createPageData({
+					name: 'XYZ Org',
+					logo: 'https://cdn.example.com/xyz-logo.png',
+					shortcode: 'xyz'
+				})
+			});
+			const img = screen.getByRole('img');
+			expect(img).toBeInTheDocument();
+			expect(img).toHaveAttribute('src', 'https://cdn.example.com/xyz-logo.png');
+			expect(img).toHaveAttribute('alt', 'XYZ Org');
+		});
+
+		it('should not show SASHAKT heading when org has shortcode and logo configured', () => {
+			render(LoginPage, {
+				data: createPageData({
+					name: 'XYZ Org',
+					logo: 'https://cdn.example.com/xyz-logo.png',
+					shortcode: 'xyz'
+				})
+			});
+			expect(screen.queryByText('SASHAKT')).not.toBeInTheDocument();
+		});
+
+		it('should fall back to SASHAKT when org has shortcode but no logo', () => {
+			render(LoginPage, {
+				data: createPageData({ name: 'XYZ Org', logo: '', shortcode: 'xyz' })
+			});
+			expect(screen.getByText('SASHAKT')).toBeInTheDocument();
+			expect(screen.queryByRole('img')).not.toBeInTheDocument();
+		});
 	});
 
 	describe('Forgot Password Link', () => {


### PR DESCRIPTION
fixes :  #540 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for organization-dependent sidebar links, including conditional rendering and correct link targets for Analytics and Platform Guide PDF.
  * Added tests for retrieving organization layout settings, verifying settings-to-URL mapping and robust fallback behavior on missing or failed API responses.
  * Added admin layout loader tests to confirm proper use of organization settings and correct handling when user/organization context is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->