### PR TITLE
fix: reset batch selection when switching between test pages

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -168,7 +168,7 @@
 	};
 
 	$effect(() => {
-		const testType = data?.is_template;
+		data?.is_template;
 		handleClearSelection();
 	});
 </script>

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -166,6 +166,11 @@
 			clearTableSelection = false;
 		}, 0);
 	};
+
+	$effect(() => {
+		const testType = data?.is_template;
+		handleClearSelection();
+	});
 </script>
 
 <DeleteDialog


### PR DESCRIPTION
## Fixes #519

##  Description
This PR fixes the issue where the batch selection toolbar persisted when navigating between the **Tests** and **Test Templates** pages.

###  Changes Made
- Reset the batch selection state when switching between test pages.
- Cleared selected items and batch delete mode on page navigation.
- Ensured the selection toolbar does not persist across different test pages.

### Screenshots
<img width="1896" height="893" alt="image" src="https://github.com/user-attachments/assets/2ed09286-f161-457f-a731-d668d58fa015" />
<img width="1917" height="897" alt="image" src="https://github.com/user-attachments/assets/e55f8401-7464-4406-be9d-f194fb18c8de" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selection is now cleared automatically when switching between template and non-template test views, preventing stale table selections from carrying over.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->