### PR TITLE
Improve Tag Chip Display

### DIFF
--- a/src/lib/components/data-table/TagCell.svelte.test.ts
+++ b/src/lib/components/data-table/TagCell.svelte.test.ts
@@ -103,17 +103,6 @@ describe('TagCell', () => {
 			const tagChip = container.querySelector('[data-slot="tag-chip"]');
 			expect(tagChip).toBeInTheDocument();
 		});
-
-		it('should apply truncate class to tag text', () => {
-			render(TagCell, {
-				props: {
-					tags: [{ name: 'Math' }]
-				}
-			});
-
-			const span = screen.getByText('Math');
-			expect(span).toHaveClass('truncate');
-		});
 	});
 
 	describe('Tooltip', () => {
@@ -169,7 +158,6 @@ describe('TagCell', () => {
 
 			const span = screen.getByText(longTag);
 			expect(span).toBeInTheDocument();
-			expect(span).toHaveClass('truncate');
 		});
 	});
 });

--- a/src/lib/components/ui/tag-chip/TagChip.svelte
+++ b/src/lib/components/ui/tag-chip/TagChip.svelte
@@ -2,6 +2,7 @@
 	import { cn } from '$lib/utils';
 	import type { Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
+	import TruncatedTextCell from '$lib/components/data-table/TruncatedTextCell.svelte';
 
 	let {
 		name,
@@ -17,12 +18,12 @@
 <span
 	data-slot="tag-chip"
 	class={cn(
-		'bg-muted text-muted-foreground inline-flex max-w-full items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
+		'bg-muted text-muted-foreground inline-flex max-w-45 items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
 		className
 	)}
 	{...restProps}
 >
-	<span class="whitespace-normal break-all">{name}</span>
+	<TruncatedTextCell value={name} />
 	{#if children}
 		{@render children()}
 	{/if}

--- a/src/lib/components/ui/tag-chip/TagChip.svelte
+++ b/src/lib/components/ui/tag-chip/TagChip.svelte
@@ -2,7 +2,6 @@
 	import { cn } from '$lib/utils';
 	import type { Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
-	import TruncatedTextCell from '$lib/components/data-table/TruncatedTextCell.svelte';
 
 	let {
 		name,
@@ -18,12 +17,12 @@
 <span
 	data-slot="tag-chip"
 	class={cn(
-		'bg-muted text-muted-foreground inline-flex max-w-45 items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
+		'bg-muted text-muted-foreground group inline-flex items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
 		className
 	)}
 	{...restProps}
 >
-	<TruncatedTextCell value={name} />
+	{name}
 	{#if children}
 		{@render children()}
 	{/if}

--- a/src/lib/components/ui/tag-chip/TagChip.svelte
+++ b/src/lib/components/ui/tag-chip/TagChip.svelte
@@ -17,12 +17,12 @@
 <span
 	data-slot="tag-chip"
 	class={cn(
-		'bg-muted text-muted-foreground inline-flex items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
+		'bg-muted text-muted-foreground inline-flex max-w-full items-center gap-1 rounded-full border border-transparent px-3 py-1 text-xs font-normal transition-colors',
 		className
 	)}
 	{...restProps}
 >
-	<span class="truncate">{name}</span>
+	<span class="whitespace-normal break-all">{name}</span>
 	{#if children}
 		{@render children()}
 	{/if}

--- a/src/routes/(admin)/tags/TagChip.svelte
+++ b/src/routes/(admin)/tags/TagChip.svelte
@@ -26,7 +26,7 @@
 		onCancelEdit?: () => void;
 	} = $props();
 
-	let hovered = $state(false);
+
 </script>
 
 {#if isEditing}
@@ -73,24 +73,20 @@
 {:else}
 	<!-- Default state: tag chip with hover edit/delete icons -->
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<TagChip
-		name={tag.name}
-		onmouseenter={() => (hovered = true)}
-		onmouseleave={() => (hovered = false)}
-	>
-		{#if hovered && canEdit}
+	<TagChip name={tag.name}>
+		{#if canEdit}
 			<button
 				type="button"
-				class="text-muted-foreground hover:text-foreground"
+				class="invisible text-muted-foreground group-hover:visible hover:text-foreground"
 				onclick={() => onEdit?.(tag.id, tag.name)}
 			>
 				<Pencil class="h-3 w-3" />
 			</button>
 		{/if}
-		{#if hovered && canDelete}
+		{#if canDelete}
 			<button
 				type="button"
-				class="text-muted-foreground hover:text-destructive"
+				class="invisible text-muted-foreground group-hover:visible hover:text-destructive"
 				onclick={() => onDelete?.(tag.id, tag.name)}
 			>
 				<Trash2 class="h-3 w-3" />

--- a/src/routes/(admin)/tags/TagChip.svelte.test.ts
+++ b/src/routes/(admin)/tags/TagChip.svelte.test.ts
@@ -82,7 +82,8 @@ describe('TagChip', () => {
 				await fireEvent.mouseEnter(chip);
 				expect(screen.getAllByRole('button')).toHaveLength(2);
 				await fireEvent.mouseLeave(chip);
-				expect(screen.queryByRole('button')).not.toBeInTheDocument();
+				// buttons remain in DOM (CSS group-hover controls visibility, not JS mount/unmount)
+				screen.getAllByRole('button').forEach((b) => expect(b).toHaveClass('invisible'));
 			});
 
 			it('does not show edit button on hover when canEdit is false', async () => {


### PR DESCRIPTION
Fixes #502 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tag chips now keep action buttons mounted and simply hide them until hovered, making the edit/delete controls behave more consistently.
  * Long tag text display was adjusted so chips render more cleanly within their container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->