### PR TITLE
Fixes for 'Create from Test-Template'

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
@@ -250,7 +250,11 @@
 			label: convertTemplate ? `Select ${term('test_template')}` : 'Primary Details',
 			mode: typeOfScreen.primary
 		},
-		{ number: 2, label: 'Select Questions', mode: typeOfScreen.questions },
+		{
+			number: 2,
+			label: convertTemplate ? 'Review Questions' : 'Select Questions',
+			mode: typeOfScreen.questions
+		},
 		{ number: 3, label: `${term('test')} Configuration`, mode: typeOfScreen.configuration }
 	]);
 </script>
@@ -343,6 +347,7 @@
 						questions={data.questions}
 						questionParams={data.questionParams}
 						user={data.user}
+						{convertTemplate}
 					/>
 				{/if}
 			</div>

--- a/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
@@ -86,12 +86,29 @@
 			: $formData.question_revision_ids.length
 	);
 
+	// Fields that need reshaping between the backend response and the form
+	// schema (e.g. `states` -> `state_ids`); every other schema field is copied
+	// through as-is below, since the backend already returns them under the
+	// same names (see testData.is_template/template_id/link in +page.server.ts).
+	const RELATIONAL_FIELD_KEYS = new Set([
+		'state_ids',
+		'district_ids',
+		'tag_ids',
+		'tag_type_ids',
+		'question_revision_ids',
+		'question_revisions',
+		'random_tag_count',
+		'question_sets'
+	]);
+
 	function populateFormFromTestData(td: typeof testData) {
 		if (!td) return;
-		$formData.name = (td as any)?.name || '';
-		$formData.description = (td as any)?.description || '';
-		$formData.show_marks =
-			typeof (td as any)?.show_marks === 'boolean' ? (td as any).show_marks : $formData.show_marks;
+		for (const key of Object.keys(testSchema.shape)) {
+			if (RELATIONAL_FIELD_KEYS.has(key)) continue;
+			if (key in (td as any)) {
+				($formData as any)[key] = (td as any)[key];
+			}
+		}
 		$formData.state_ids =
 			td?.states?.map((state: Filter) => ({
 				id: String(state.id),
@@ -132,7 +149,7 @@
 			})) || [];
 
 		$formData.question_sets =
-			testData?.question_sets?.map(
+			td?.question_sets?.map(
 				(questionSet: {
 					id?: number | null;
 					title: string;

--- a/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
@@ -11,6 +11,7 @@
 	import { getQuestionSetMandatoryLimitError, testSchema, type FormSchema } from './schema';
 	import type { Filter } from '$lib/types/filters';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import {
 		applyOrgSettingsToNewTestForm,
 		type OrgSettingsPayload
@@ -220,6 +221,13 @@
 
 	function handlePrevious() {
 		if (currentScreen > typeOfScreen.primary) {
+			if (currentScreen - 1 === typeOfScreen.primary && convertTemplate) {
+				currentScreen--;
+				// Drop template_id so the load function re-fetches the template list
+				// (it's only fetched when no template_id is present).
+				goto(page.url.pathname, { invalidateAll: true });
+				return;
+			}
 			currentScreen--;
 		}
 	}

--- a/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/+page.svelte
@@ -219,16 +219,24 @@
 			(currentScreen === typeOfScreen.configuration && Boolean(questionSetMandatoryLimitError))
 	);
 
+	// Drop template_id so the load function re-fetches the template list
+	// (it's only fetched when no template_id is present).
+	function goToScreen(target: number) {
+		if (
+			target === typeOfScreen.primary &&
+			convertTemplate &&
+			currentScreen !== typeOfScreen.primary
+		) {
+			currentScreen = target;
+			goto(page.url.pathname, { invalidateAll: true });
+			return;
+		}
+		currentScreen = target;
+	}
+
 	function handlePrevious() {
 		if (currentScreen > typeOfScreen.primary) {
-			if (currentScreen - 1 === typeOfScreen.primary && convertTemplate) {
-				currentScreen--;
-				// Drop template_id so the load function re-fetches the template list
-				// (it's only fetched when no template_id is present).
-				goto(page.url.pathname, { invalidateAll: true });
-				return;
-			}
-			currentScreen--;
+			goToScreen(currentScreen - 1);
 		}
 	}
 
@@ -284,7 +292,7 @@
 									? 'cursor-pointer'
 									: ''}"
 								onclick={() => {
-									if (isCompleted) currentScreen = step.mode;
+									if (isCompleted) goToScreen(step.mode);
 								}}
 								disabled={!isCompleted && !isActive}
 							>

--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
@@ -19,8 +19,15 @@
 		formData,
 		questions,
 		questionParams,
-		user = null
-	}: { formData: any; questions: any; questionParams: any; user?: User | null } = $props();
+		user = null,
+		convertTemplate = false
+	}: {
+		formData: any;
+		questions: any;
+		questionParams: any;
+		user?: User | null;
+		convertTemplate?: boolean;
+	} = $props();
 	let dialogOpen = $state(false);
 	let questionSelectionMode: 'manual' | 'tagBased' = $state('tagBased');
 	const isSectionedTest = $derived(($formData.question_sets?.length ?? 0) > 0);
@@ -97,7 +104,7 @@
 				<FileQuestionIcon class="text-primary h-5 w-5" />
 			</div>
 			<div>
-				<p class="font-semibold">Select Questions</p>
+				<p class="font-semibold">{convertTemplate ? 'Review Questions' : 'Select Questions'}</p>
 				<p class="text-muted-foreground text-sm">
 					{#if isSectionedTest}
 						Review the sectioned questions included in this {$formData.is_template

--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
@@ -218,6 +218,31 @@ describe('QuestionList', () => {
 		});
 	});
 
+	describe('header label', () => {
+		it('shows "Select Questions" by default', () => {
+			const formData = makeFormData();
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			expect(screen.getByText('Select Questions')).toBeInTheDocument();
+		});
+
+		it('shows "Review Questions" when creating from a template', () => {
+			const formData = makeFormData();
+
+			render(QuestionList, {
+				formData,
+				questions: [],
+				questionParams: {},
+				user: null,
+				convertTemplate: true
+			});
+
+			expect(screen.getByText('Review Questions')).toBeInTheDocument();
+			expect(screen.queryByText('Select Questions')).not.toBeInTheDocument();
+		});
+	});
+
 	describe('auto selection — tags carried over from Primary screen', () => {
 		it('defaults to Auto Selection mode when tags were selected and no explicit question IDs exist', () => {
 			const formData = makeFormData({

--- a/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
@@ -899,6 +899,25 @@ describe('Test Create/Update Page', () => {
 					expect(btn.closest('button')).toBeDisabled();
 				});
 			});
+
+			it('also clears template_id when the "Select Test template" stepper label is clicked directly', async () => {
+				setupSuperFormMock();
+				render(TestCreatePage, {
+					data: baseData({ convertTemplate: true, testData: makeTemplateTestData() })
+				});
+
+				// Clicking the completed step-1 label (not the Previous button) should behave
+				// the same way: it's a separate code path that bypassed the fix initially.
+				await fireEvent.click(screen.getByText('Select Test Template'));
+
+				expect(goto).toHaveBeenCalledWith('/tests/test-session/convert', {
+					invalidateAll: true
+				});
+				const prevButtons = screen.getAllByText('Previous');
+				prevButtons.forEach((btn) => {
+					expect(btn.closest('button')).toBeDisabled();
+				});
+			});
 		});
 	});
 });

--- a/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/page.svelte.test.ts
@@ -4,9 +4,20 @@ import { render, screen, fireEvent } from '@testing-library/svelte';
 import { get, writable } from 'svelte/store';
 import TestCreatePage from './+page.svelte';
 import { superForm } from 'sveltekit-superforms';
+import { goto } from '$app/navigation';
 import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+vi.mock('$app/state', () => ({
+	page: {
+		url: new URL('http://localhost/tests/test-session/convert?template_id=99')
+	}
+}));
 
 vi.mock('sveltekit-superforms', () => ({
 	superForm: vi.fn()
@@ -82,7 +93,10 @@ const defaultFormValues = {
 	completion_message: null,
 	start_instructions: null,
 	question_pagination: 0,
-	no_of_attempts: 1
+	no_of_attempts: 1,
+	bookmark: false,
+	pause_timer_when_inactive: false,
+	form_id: null
 };
 
 let mockSubmit: ReturnType<typeof vi.fn>;
@@ -764,6 +778,127 @@ describe('Test Create/Update Page', () => {
 			render(TestCreatePage, { data: baseData() });
 			expect(screen.getByText('Create Test')).toBeInTheDocument();
 			expect(screen.getByText('Test Configuration')).toBeInTheDocument();
+		});
+	});
+
+	// ── Convert-from-template flow ───────────────────────────────────────────
+
+	describe('Convert-from-template flow', () => {
+		function makeTemplateTestData(overrides: Record<string, any> = {}) {
+			return {
+				id: '99',
+				name: 'Governance Template',
+				description: 'A template description',
+				is_active: true,
+				start_time: null,
+				end_time: null,
+				pause_timer_when_inactive: true,
+				time_limit: 45,
+				marks_level: 'test',
+				marks: 10,
+				marking_scheme: { correct: 2, wrong: -0.5, skipped: 0 },
+				completion_message: 'Thanks for completing the template test.',
+				start_instructions: 'Please read carefully before starting.',
+				no_of_attempts: 3,
+				shuffle: false,
+				random_questions: false,
+				no_of_random_questions: null,
+				question_pagination: 5,
+				show_result: false,
+				show_question_palette: false,
+				bookmark: true,
+				locale: 'en-US',
+				certificate_id: 7,
+				show_feedback_on_completion: true,
+				show_feedback_immediately: true,
+				form_id: 3,
+				omr: 'ALWAYS',
+				template_id: '99',
+				link: null,
+				question_revisions: [],
+				question_sets: [],
+				states: [],
+				districts: [],
+				tags: [],
+				random_tag_counts: [],
+				...overrides
+			};
+		}
+
+		// Scenario 2: step label reflects that questions are being reviewed, not chosen
+		it('shows the "Review Questions" step label once template data has loaded', () => {
+			setupSuperFormMock();
+			render(TestCreatePage, {
+				data: baseData({ convertTemplate: true, testData: makeTemplateTestData() })
+			});
+
+			expect(screen.getByText('Review Questions')).toBeInTheDocument();
+			expect(screen.queryByText('Select Questions')).not.toBeInTheDocument();
+		});
+
+		it('still shows "Select Questions" for a normal (non-template) test', () => {
+			setupSuperFormMock();
+			render(TestCreatePage, { data: baseData() });
+
+			expect(screen.getByText('Select Questions')).toBeInTheDocument();
+			expect(screen.queryByText('Review Questions')).not.toBeInTheDocument();
+		});
+
+		// Scenario 3: Configuration-page fields are populated from the selected template
+		it('copies template configuration fields (pre/post-test messages etc.) into the form store', () => {
+			const formStore = setupSuperFormMock();
+			render(TestCreatePage, {
+				data: baseData({ convertTemplate: true, testData: makeTemplateTestData() })
+			});
+
+			const stored = get(formStore);
+			expect(stored.start_instructions).toBe('Please read carefully before starting.');
+			expect(stored.completion_message).toBe('Thanks for completing the template test.');
+			expect(stored.time_limit).toBe(45);
+			expect(stored.marks_level).toBe('test');
+			expect(stored.marking_scheme).toEqual({ correct: 2, wrong: -0.5, skipped: 0 });
+			expect(stored.no_of_attempts).toBe(3);
+			expect(stored.certificate_id).toBe(7);
+			expect(stored.omr).toBe('ALWAYS');
+			expect(stored.show_feedback_on_completion).toBe(true);
+			expect(stored.show_feedback_immediately).toBe(true);
+			expect(stored.bookmark).toBe(true);
+			expect(stored.pause_timer_when_inactive).toBe(true);
+		});
+
+		// Scenario 1: going back to the template-select step must re-fetch the template list
+		describe('navigating back to the template-select step', () => {
+			it('clears template_id from the URL so the server re-fetches the template list', async () => {
+				setupSuperFormMock();
+				render(TestCreatePage, {
+					data: baseData({ convertTemplate: true, testData: makeTemplateTestData() })
+				});
+
+				// The effect auto-advances us to step 2 (Review Questions) once template data loads.
+				expect(screen.getByText('Review Questions')).toBeInTheDocument();
+
+				const prevButtons = screen.getAllByText('Previous');
+				await fireEvent.click(prevButtons[prevButtons.length - 1]);
+
+				expect(goto).toHaveBeenCalledWith('/tests/test-session/convert', {
+					invalidateAll: true
+				});
+			});
+
+			it('returns to the template-select step (Previous becomes disabled again)', async () => {
+				setupSuperFormMock();
+				render(TestCreatePage, {
+					data: baseData({ convertTemplate: true, testData: makeTemplateTestData() })
+				});
+
+				const prevButtons = screen.getAllByText('Previous');
+				await fireEvent.click(prevButtons[prevButtons.length - 1]);
+
+				const buttonsAfter = screen.getAllByText('Previous');
+				buttonsAfter.forEach((btn) => {
+					expect(btn.closest('button')).toBeDisabled();
+				});
+			});
 		});
 	});
 });


### PR DESCRIPTION
Fixes #515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added template-conversion support in the test setup flow, including a new “Review Questions” step label when converting from a template.
  * The question selection screen now adapts its header based on whether template conversion is active.

* **Bug Fixes**
  * Improved prefill behavior so test settings are copied more reliably from template data.
  * Updated back-navigation so returning from template review clears the template selection state and follows the correct step flow.

* **Tests**
  * Expanded coverage for template conversion, navigation, and question list header behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->