### PR TITLE
Implement sorting functionality for candidate responses

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.server.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.server.ts
@@ -14,10 +14,13 @@ export const load: PageServerLoad = async ({ params, url }) => {
 
 	const page = Number(url.searchParams.get('page')) || 1;
 	const size = Number(url.searchParams.get('size')) || DEFAULT_PAGE_SIZE;
+	const sortBy = url.searchParams.get('sortBy') || '';
+	const sortOrder = url.searchParams.get('sortOrder') || 'asc';
 
 	const queryParams = new URLSearchParams({
 		page: page.toString(),
-		size: size.toString()
+		size: size.toString(),
+		...(sortBy && { sort_by: sortBy, sort_order: sortOrder })
 	});
 
 	const [testRes, reportRes] = await Promise.all([
@@ -38,7 +41,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
 		testName: test?.name || 'Test',
 		responses,
 		totalPages: responses.pages || 0,
-		params: { page, size }
+		params: { page, size, sortBy, sortOrder }
 	};
 };
 

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
@@ -7,7 +7,8 @@
 	import { hasPermission, PERMISSIONS } from '$lib/utils/permissions.js';
 	import { DEFAULT_PAGE_SIZE } from '$lib/constants';
 	import { enhance } from '$app/forms';
-	import { invalidateAll } from '$app/navigation';
+	import { goto, invalidateAll } from '$app/navigation';
+	import { page } from '$app/state';
 
 	let { data } = $props();
 
@@ -16,6 +17,8 @@
 	const totalPages = $derived(data?.totalPages || 0);
 	const currentPage = $derived(data?.params?.page || 1);
 	const pageSize = $derived(data?.params?.size || DEFAULT_PAGE_SIZE);
+	const sortBy = $derived(data?.params?.sortBy || '');
+	const sortOrder = $derived(data?.params?.sortOrder || 'asc');
 
 	const userCanDelete = $derived(hasPermission(data.user, PERMISSIONS.DELETE_CANDIDATE));
 
@@ -31,7 +34,21 @@
 		deleteAction = `?/deleteCandidate&candidate_id=${candidateId}`;
 	}
 
-	const columns = $derived(createResponseColumns(handleDelete, userCanDelete, userCanDelete));
+	// handle sorting
+	function handleSort(columnId: string) {
+		const url = new URL(page.url);
+		const newSortOrder = sortBy === columnId && sortOrder === 'asc' ? 'desc' : 'asc';
+
+		url.searchParams.set('sortBy', columnId);
+		url.searchParams.set('sortOrder', newSortOrder);
+		url.searchParams.set('page', '1');
+
+		goto(url.toString(), { replaceState: false });
+	}
+
+	const columns = $derived(
+		createResponseColumns(sortBy, sortOrder, handleSort, handleDelete, userCanDelete, userCanDelete)
+	);
 
 	const handleSelectionChange = (selectedRows: CandidateResponse[], selectedRowIds: string[]) => {
 		selectedCandidates = selectedRows;

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/columns.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/columns.ts
@@ -3,7 +3,7 @@ import { renderComponent } from '$lib/components/ui/data-table/index.js';
 import DateCell from '$lib/components/data-table/DateCell.svelte';
 import CandidateStatusBadge from '$lib/components/data-table/CandidateStatusBadge.svelte';
 import { DataTableActions } from '$lib/components/data-table/index.js';
-import { createSelectionColumn } from '$lib/components/data-table/column-helpers';
+import { createSelectionColumn, createSortableColumn } from '$lib/components/data-table/column-helpers';
 
 type CandidateStatus = 'submitted' | 'not_submitted';
 export interface CandidateResult {
@@ -28,6 +28,9 @@ export interface CandidateResponse {
 }
 
 export const createResponseColumns = (
+	currentSortBy: string,
+	currentSortOrder: string,
+	handleSort: (columnId: string) => void,
 	onDelete?: (candidateId: number) => void,
 	canDelete = true,
 	enableSelection = false
@@ -38,12 +41,17 @@ export const createResponseColumns = (
 		header: 'Candidate',
 		meta: { grow: true }
 	},
-	{
-		accessorKey: 'status',
-		header: 'Status',
-		cell: ({ row }) => renderComponent(CandidateStatusBadge, { status: row.original.status }),
-		size: 150
-	},
+	createSortableColumn(
+		'status',
+		'Status',
+		currentSortBy,
+		currentSortOrder,
+		handleSort,
+		{
+			cell: ({ row }) => renderComponent(CandidateStatusBadge, { status: row.original.status }),
+			size: 150
+		}
+	),
 	{
 		id: 'marks',
 		header: 'Marks',
@@ -55,12 +63,17 @@ export const createResponseColumns = (
 		},
 		size: 130
 	},
-	{
-		accessorKey: 'start_time',
-		header: 'Start Time',
-		cell: ({ row }) => renderComponent(DateCell, { value: row.original.start_time ?? '' }),
-		size: 180
-	},
+	createSortableColumn(
+		'start_time',
+		'Start Time',
+		currentSortBy,
+		currentSortOrder,
+		handleSort,
+		{
+			cell: ({ row }) => renderComponent(DateCell, { value: row.original.start_time ?? '' }),
+			size: 180
+		}
+	),
 	{
 		accessorKey: 'end_time',
 		header: 'End Time',

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/page.server.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/page.server.test.ts
@@ -91,7 +91,7 @@ describe('Candidate Responses Route', () => {
 			expect(result.testName).toBe('Algebra Test');
 			expect(result.responses).toEqual({ items: [{ candidate_id: 1 }], total: 1, pages: 1 });
 			expect(result.totalPages).toBe(1);
-			expect(result.params).toEqual({ page: 1, size: 25 });
+			expect(result.params).toEqual({ page: 1, size: 25, sortBy: '', sortOrder: 'asc' });
 		});
 
 		it('passes custom page/size params to the candidate-report API', async () => {
@@ -108,7 +108,7 @@ describe('Candidate Responses Route', () => {
 			const reportCallUrl = mockFetch.mock.calls[1][0];
 			expect(reportCallUrl).toContain('page=3');
 			expect(reportCallUrl).toContain('size=10');
-			expect(result.params).toEqual({ page: 3, size: 10 });
+			expect(result.params).toEqual({ page: 3, size: 10, sortBy: '', sortOrder: 'asc' });
 		});
 
 		it('uses Bearer token when fetching the test and the candidate report', async () => {


### PR DESCRIPTION
fixed : #561 
depends : https://github.com/sashakt-platform/sashakt-core/pull/555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sortable response columns in the admin tests view, including sort state in the URL.
  * Sorting now works for status and start time, with click-to-toggle behavior.

* **Bug Fixes**
  * Pagination now resets to the first page when a new sort is applied.
  * The page now preserves and returns sort settings alongside existing paging values.

* **Tests**
  * Updated coverage to reflect default sorting values in returned page data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->