### PR TITLE
Add selection mode switching functionality 

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
@@ -10,6 +10,7 @@
 	import type { Filter } from '$lib/types/filters';
 	import type { User } from '$lib/utils/permissions.js';
 	import { Tabs, TabsList, TabsTrigger } from '$lib/components/ui/tabs';
+	import SwitchSelectionModeDialog from './SwitchSelectionModeDialog.svelte';
 	import SectionedQuestionSets from './SectionedQuestionSets.svelte';
 	import { useTerms } from '$lib/nomenclature';
 
@@ -30,6 +31,10 @@
 	} = $props();
 	let dialogOpen = $state(false);
 	let questionSelectionMode: 'manual' | 'tagBased' = $state('tagBased');
+
+	let tabsValue: 'manual' | 'tagBased' = $state('tagBased');
+	let pendingMode: 'manual' | 'tagBased' | null = $state(null);
+	const confirmSwitchOpen = $derived(pendingMode !== null);
 	const isSectionedTest = $derived(($formData.question_sets?.length ?? 0) > 0);
 	const sectionedQuestionCount = $derived(
 		($formData.question_sets || []).reduce(
@@ -81,6 +86,7 @@
 			questionSelectionMode = 'tagBased';
 			syncTagsFromTagIds();
 		}
+		tabsValue = questionSelectionMode;
 	}
 
 	const handleRemoveQuestion = (questionId: number) => {
@@ -91,10 +97,52 @@
 			(question: { id: number }) => question.id !== questionId
 		);
 	};
+
+	const applyModeSwitch = (newMode: 'manual' | 'tagBased') => {
+		if (newMode === 'manual') {
+			$formData.random_tag_count = [];
+		} else {
+			$formData.question_revision_ids = [];
+			$formData.question_revisions = [];
+			syncTagsFromTagIds();
+		}
+		questionSelectionMode = newMode;
+		tabsValue = newMode;
+	};
+
+	const handleTabChange = (newMode: 'manual' | 'tagBased') => {
+		const currentTabHasSelections =
+			questionSelectionMode === 'manual'
+				? $formData.question_revision_ids.length > 0
+				: $formData.random_tag_count.length > 0;
+
+		if (currentTabHasSelections) {
+			pendingMode = newMode;
+			tabsValue = questionSelectionMode;
+			return;
+		}
+
+		applyModeSwitch(newMode);
+	};
+
+	const confirmTabSwitch = () => {
+		if (pendingMode) applyModeSwitch(pendingMode);
+		pendingMode = null;
+	};
+
+	const cancelTabSwitch = () => {
+		pendingMode = null;
+	};
 </script>
 
 {#if !isSectionedTest}
 	<QuestionSelectionDialog bind:open={dialogOpen} {questions} {questionParams} {formData} {user} />
+
+	<SwitchSelectionModeDialog
+		open={confirmSwitchOpen}
+		onConfirm={confirmTabSwitch}
+		onCancel={cancelTabSwitch}
+	/>
 {/if}
 
 <div class="bg-card overflow-hidden rounded-xl border shadow-sm">
@@ -131,15 +179,10 @@
 			</div>
 		{:else}
 			<Tabs
-				bind:value={questionSelectionMode}
+				bind:value={tabsValue}
 				class="w-fit"
-				onValueChange={(v) => {
-					if (v === 'manual') $formData.random_tag_count = [];
-					if (v === 'tagBased') {
-						$formData.question_revision_ids = [];
-						syncTagsFromTagIds();
-					}
-				}}
+				activationMode="manual"
+				onValueChange={(newMode) => handleTabChange(newMode as 'manual' | 'tagBased')}
 			>
 				<TabsList class="bg-muted rounded-full p-1">
 					<TabsTrigger

--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
 import { get, writable } from 'svelte/store';
 import { describe, expect, it, vi } from 'vitest';
 import QuestionList from './QuestionList.svelte';
@@ -367,6 +367,91 @@ describe('QuestionList', () => {
 			// Manual mode shows the question count header, not the auto-selection description
 			expect(screen.queryByText(/Select tags and specify/)).not.toBeInTheDocument();
 			expect(screen.getByText(/2 questions added/)).toBeInTheDocument();
+		});
+	});
+
+	describe('switching selection mode with unsaved selections', () => {
+		it('warns before discarding manually selected questions when switching to Auto Selection', async () => {
+			const formData = makeFormData({
+				question_revision_ids: [101, 102],
+				question_revisions: [
+					{ id: 101, question_text: 'Q1', tags: [] },
+					{ id: 102, question_text: 'Q2', tags: [] }
+				]
+			});
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			await fireEvent.click(screen.getByText('Auto Selection'));
+
+			expect(screen.getByText('Switch selection mode?')).toBeInTheDocument();
+			expect(get(formData).question_revision_ids).toEqual([101, 102]);
+		});
+
+		it('keeps the current tab and selections when the switch is cancelled', async () => {
+			const formData = makeFormData({
+				question_revision_ids: [101, 102],
+				question_revisions: [
+					{ id: 101, question_text: 'Q1', tags: [] },
+					{ id: 102, question_text: 'Q2', tags: [] }
+				]
+			});
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			await fireEvent.click(screen.getByText('Auto Selection'));
+			await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+			expect(screen.queryByText('Switch selection mode?')).not.toBeInTheDocument();
+			expect(screen.getByText(/2 questions added/)).toBeInTheDocument();
+			expect(get(formData).question_revision_ids).toEqual([101, 102]);
+		});
+
+		it('clears manually selected questions and switches tabs when the switch is confirmed', async () => {
+			const formData = makeFormData({
+				question_revision_ids: [101, 102],
+				question_revisions: [
+					{ id: 101, question_text: 'Q1', tags: [] },
+					{ id: 102, question_text: 'Q2', tags: [] }
+				]
+			});
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			await fireEvent.click(screen.getByText('Auto Selection'));
+			await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+			expect(screen.queryByText('Switch selection mode?')).not.toBeInTheDocument();
+			expect(get(formData).question_revision_ids).toEqual([]);
+			expect(get(formData).question_revisions).toEqual([]);
+			expect(
+				screen.getByText(/Select tags and specify how many questions to randomly pull from each/)
+			).toBeInTheDocument();
+		});
+
+		it('warns before discarding random tag rules when switching to Manual Selection', async () => {
+			const formData = makeFormData({
+				tag_ids: [{ id: '1', name: 'Science' }],
+				random_tag_count: [{ id: '1', name: 'Science', count: 5 }]
+			});
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			await fireEvent.click(screen.getByText('Manual Selection'));
+
+			expect(screen.getByText('Switch selection mode?')).toBeInTheDocument();
+			expect(get(formData).random_tag_count).toEqual([{ id: '1', name: 'Science', count: 5 }]);
+		});
+
+		it('switches tabs immediately when the current tab has no selections', async () => {
+			const formData = makeFormData();
+
+			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
+
+			await fireEvent.click(screen.getByText('Manual Selection'));
+
+			expect(screen.queryByText('Switch selection mode?')).not.toBeInTheDocument();
+			expect(screen.getByText('No questions yet')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/routes/(admin)/tests/test-[type]/[id]/SwitchSelectionModeDialog.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/SwitchSelectionModeDialog.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+
+	let {
+		open = $bindable(false),
+		onConfirm,
+		onCancel
+	}: {
+		open: boolean;
+		onConfirm: () => void;
+		onCancel: () => void;
+	} = $props();
+</script>
+
+<AlertDialog.Root
+	bind:open
+	onOpenChange={(isOpen) => {
+		if (!isOpen) onCancel();
+	}}
+>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Switch selection mode?</AlertDialog.Title>
+			<AlertDialog.Description>
+				Switching selection mode will remove your currently selected questions. Continue?
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel onclick={onCancel}>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action onclick={onConfirm}>Continue</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/routes/(admin)/tests/test-[type]/[id]/SwitchSelectionModeDialog.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/SwitchSelectionModeDialog.svelte
@@ -22,7 +22,8 @@
 		<AlertDialog.Header>
 			<AlertDialog.Title>Switch selection mode?</AlertDialog.Title>
 			<AlertDialog.Description>
-				Switching selection mode will remove your currently selected questions. Continue?
+				Switching selection mode will remove your currently selected questions. Do you want to
+				continue?
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>


### PR DESCRIPTION
fixs :- #567 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when switching between manual and automatic question selection modes while existing selections are present.
  * **Cancel** keeps the current mode and selections; **Continue** switches modes and clears affected selection data.
  * If no selections would be lost, mode changes apply immediately.
* **Bug Fixes**
  * Prevented accidental loss of configured questions and selection rules when changing selection modes.
* **Tests**
  * Added coverage for confirm/cancel flows and scenarios with or without existing selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->