### PR TITLE
Refactor Candidate Responses table

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/columns.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/columns.ts
@@ -37,9 +37,15 @@ export const createResponseColumns = (
 ): ColumnDef<CandidateResponse>[] => [
 	...(enableSelection ? [createSelectionColumn<CandidateResponse>()] : []),
 	{
-		accessorKey: 'candidate_uuid',
-		header: 'Candidate',
-		meta: { grow: true }
+		id: 'marks',
+		header: 'Marks',
+		cell: ({ row }) => {
+			const result = row.original.result;
+			if (!result || result.marks_obtained == null) return '—';
+			if (result.marks_maximum == null) return `${result.marks_obtained}`;
+			return `${result.marks_obtained} / ${result.marks_maximum}`;
+		},
+		size: 130
 	},
 	createSortableColumn(
 		'status',
@@ -52,17 +58,6 @@ export const createResponseColumns = (
 			size: 150
 		}
 	),
-	{
-		id: 'marks',
-		header: 'Marks',
-		cell: ({ row }) => {
-			const result = row.original.result;
-			if (!result || result.marks_obtained == null) return '—';
-			if (result.marks_maximum == null) return `${result.marks_obtained}`;
-			return `${result.marks_obtained} / ${result.marks_maximum}`;
-		},
-		size: 130
-	},
 	createSortableColumn(
 		'start_time',
 		'Start Time',

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
@@ -123,7 +123,9 @@ describe('Candidate Responses page (UI)', () => {
 
 		it('shows a dash for marks when the candidate has no result', () => {
 			render(ResponsesPage, { data: makeData([notSubmittedCandidate]) } as any);
-			expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+			const row = screen.getByText('Not Submitted').closest('tr') as HTMLElement;
+			const cells = within(row).getAllByRole('cell');
+			expect(cells[0]).toHaveTextContent('—');
 		});
 
 		it('shows formatted start/end time for a submitted candidate', () => {
@@ -139,7 +141,10 @@ describe('Candidate Responses page (UI)', () => {
 		it('shows a dash (not "Invalid Date") for start/end time when the candidate has not submitted', () => {
 			render(ResponsesPage, { data: makeData([notSubmittedCandidate]) } as any);
 			expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument();
-			expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+			const row = screen.getByText('Not Submitted').closest('tr') as HTMLElement;
+			const cells = within(row).getAllByRole('cell');
+			expect(cells[2]).toHaveTextContent('—');
+			expect(cells[3]).toHaveTextContent('—');
 		});
 
 		it('shows "Xm Ys" time taken for a submitted candidate', () => {
@@ -149,7 +154,9 @@ describe('Candidate Responses page (UI)', () => {
 
 		it('shows a dash for time taken when the candidate has not submitted', () => {
 			render(ResponsesPage, { data: makeData([notSubmittedCandidate]) } as any);
-			expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+			const row = screen.getByText('Not Submitted').closest('tr') as HTMLElement;
+			const cells = within(row).getAllByRole('cell');
+			expect(cells[4]).toHaveTextContent('—');
 		});
 	});
 

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
@@ -83,9 +83,8 @@ describe('Candidate Responses page (UI)', () => {
 
 		it('shows all table column headers', () => {
 			render(ResponsesPage, { data: makeData() } as any);
-			expect(screen.getByRole('columnheader', { name: 'Candidate' })).toBeInTheDocument();
-			expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
 			expect(screen.getByRole('columnheader', { name: 'Marks' })).toBeInTheDocument();
+			expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
 			expect(screen.getByRole('columnheader', { name: 'Start Time' })).toBeInTheDocument();
 			expect(screen.getByRole('columnheader', { name: 'End Time' })).toBeInTheDocument();
 			expect(screen.getByRole('columnheader', { name: 'Time Taken' })).toBeInTheDocument();
@@ -107,12 +106,6 @@ describe('Candidate Responses page (UI)', () => {
 
 	// ─────────────────────────────────────────────────────────────────────────
 	describe('Table row content', () => {
-		it('shows the candidate identifier', () => {
-			render(ResponsesPage, { data: makeData() } as any);
-			expect(screen.getByText('candidate-aaa')).toBeInTheDocument();
-			expect(screen.getByText('candidate-bbb')).toBeInTheDocument();
-		});
-
 		it('shows a "Submitted" badge for submitted candidates', () => {
 			render(ResponsesPage, { data: makeData() } as any);
 			expect(screen.getByText('Submitted')).toBeInTheDocument();
@@ -146,8 +139,7 @@ describe('Candidate Responses page (UI)', () => {
 		it('shows a dash (not "Invalid Date") for start/end time when the candidate has not submitted', () => {
 			render(ResponsesPage, { data: makeData([notSubmittedCandidate]) } as any);
 			expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument();
-			const row = screen.getByText('candidate-bbb').closest('tr') as HTMLElement;
-			expect(within(row).getAllByText('—').length).toBeGreaterThan(0);
+			expect(screen.getAllByText('—').length).toBeGreaterThan(0);
 		});
 
 		it('shows "Xm Ys" time taken for a submitted candidate', () => {
@@ -157,8 +149,7 @@ describe('Candidate Responses page (UI)', () => {
 
 		it('shows a dash for time taken when the candidate has not submitted', () => {
 			render(ResponsesPage, { data: makeData([notSubmittedCandidate]) } as any);
-			const row = screen.getByText('candidate-bbb').closest('tr') as HTMLElement;
-			expect(within(row).getAllByText('—').length).toBeGreaterThan(0);
+			expect(screen.getAllByText('—').length).toBeGreaterThan(0);
 		});
 	});
 


### PR DESCRIPTION
fixes :-  #569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Changes**
  * Updated the test responses table layout so the **Marks** column appears earlier, and the **Candidate** column is no longer shown in that position.

* **Bug Fixes**
  * Improved the consistency of missing values by ensuring non-submitted rows display dashes for marks and related timing fields.

* **Tests**
  * Refreshed the UI test suite to match the revised table headers and row-scoped missing-value assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->