### PR TITLE
Add search functionality to candidate responses page

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.server.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.server.ts
@@ -14,12 +14,14 @@ export const load: PageServerLoad = async ({ params, url }) => {
 
 	const page = Number(url.searchParams.get('page')) || 1;
 	const size = Number(url.searchParams.get('size')) || DEFAULT_PAGE_SIZE;
+	const search = url.searchParams.get('search') || '';
 	const sortBy = url.searchParams.get('sortBy') || '';
 	const sortOrder = url.searchParams.get('sortOrder') || 'asc';
 
 	const queryParams = new URLSearchParams({
 		page: page.toString(),
 		size: size.toString(),
+		...(search && { search }),
 		...(sortBy && { sort_by: sortBy, sort_order: sortOrder })
 	});
 
@@ -41,7 +43,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
 		testName: test?.name || 'Test',
 		responses,
 		totalPages: responses.pages || 0,
-		params: { page, size, sortBy, sortOrder }
+		params: { page, size, search, sortBy, sortOrder }
 	};
 };
 

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
@@ -3,6 +3,7 @@
 	import { DataTable } from '$lib/components/data-table/index.js';
 	import DeleteDialog from '$lib/components/DeleteDialog.svelte';
 	import BatchActionsToolbar from '$lib/components/data-table/BatchActionsToolbar.svelte';
+	import SearchInput from '$lib/components/SearchInput.svelte';
 	import { createResponseColumns, type CandidateResponse } from './columns.js';
 	import { hasPermission, PERMISSIONS } from '$lib/utils/permissions.js';
 	import { DEFAULT_PAGE_SIZE } from '$lib/constants';
@@ -19,6 +20,7 @@
 	const pageSize = $derived(data?.params?.size || DEFAULT_PAGE_SIZE);
 	const sortBy = $derived(data?.params?.sortBy || '');
 	const sortOrder = $derived(data?.params?.sortOrder || 'asc');
+	const search = $derived(data?.params?.search || '');
 
 	const userCanDelete = $derived(hasPermission(data.user, PERMISSIONS.DELETE_CANDIDATE));
 
@@ -125,6 +127,10 @@
 				onClearSelection={handleClearSelection}
 			/>
 		{/if}
+	{/snippet}
+
+	{#snippet filters()}
+		<SearchInput placeholder="Search candidates..." value={search} />
 	{/snippet}
 
 	{#snippet content()}

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/page.server.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/page.server.test.ts
@@ -91,7 +91,13 @@ describe('Candidate Responses Route', () => {
 			expect(result.testName).toBe('Algebra Test');
 			expect(result.responses).toEqual({ items: [{ candidate_id: 1 }], total: 1, pages: 1 });
 			expect(result.totalPages).toBe(1);
-			expect(result.params).toEqual({ page: 1, size: 25, sortBy: '', sortOrder: 'asc' });
+			expect(result.params).toEqual({
+				page: 1,
+				size: 25,
+				search: '',
+				sortBy: '',
+				sortOrder: 'asc'
+			});
 		});
 
 		it('passes custom page/size params to the candidate-report API', async () => {
@@ -108,7 +114,13 @@ describe('Candidate Responses Route', () => {
 			const reportCallUrl = mockFetch.mock.calls[1][0];
 			expect(reportCallUrl).toContain('page=3');
 			expect(reportCallUrl).toContain('size=10');
-			expect(result.params).toEqual({ page: 3, size: 10, sortBy: '', sortOrder: 'asc' });
+			expect(result.params).toEqual({
+				page: 3,
+				size: 10,
+				search: '',
+				sortBy: '',
+				sortOrder: 'asc'
+			});
 		});
 
 		it('uses Bearer token when fetching the test and the candidate report', async () => {


### PR DESCRIPTION
fixes: #576
Depends :- https://github.com/sashakt-platform/sashakt-core/pull/566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a candidate search control to the admin “responses” page.
  * Preserves the current search term when using pagination and sorting.

* **Bug Fixes**
  * Ensures the search criteria are included in backend requests and reflected in the page parameters.

* **Tests**
  * Expanded route `load()` test assertions to verify search parameters for both default and custom pagination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->