### PR TITLE
Add export functionality for candidate responses

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
@@ -143,12 +143,14 @@
 	showInfoIcon={false}
 >
 	{#snippet headerActions()}
-		<a href={resolve(exportHref as any)} download>
-			<Button variant="outline" class="border-primary text-primary bg-card font-semibold">
-				<Download class="h-4 w-4" />
-				Export
-			</Button>
-		</a>
+		{#if totalItems > 0}
+			<a href={resolve(exportHref as any)} download>
+				<Button variant="outline" class="border-primary text-primary bg-card font-semibold">
+					<Download class="h-4 w-4" />
+					Export
+				</Button>
+			</a>
+		{/if}
 	{/snippet}
 
 	{#snippet toolbar()}

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
@@ -144,12 +144,15 @@
 >
 	{#snippet headerActions()}
 		{#if totalItems > 0}
-			<a href={resolve(exportHref as any)} download>
-				<Button variant="outline" class="border-primary text-primary bg-card font-semibold">
-					<Download class="h-4 w-4" />
-					Export
-				</Button>
-			</a>
+			<Button
+				href={resolve(exportHref as any)}
+				download
+				variant="outline"
+				class="border-primary text-primary bg-card font-semibold"
+			>
+				<Download class="h-4 w-4" />
+				Export
+			</Button>
 		{/if}
 	{/snippet}
 

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
@@ -11,6 +11,9 @@
 	import { enhance } from '$app/forms';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import Download from '@lucide/svelte/icons/download';
 
 	let { data } = $props();
 
@@ -24,6 +27,10 @@
 	const search = $derived(data?.params?.search || '');
 
 	const userCanDelete = $derived(hasPermission(data.user, PERMISSIONS.DELETE_CANDIDATE));
+
+	const exportHref = $derived(
+		`${page.url.pathname}/export?sortBy=${encodeURIComponent(sortBy)}&sortOrder=${encodeURIComponent(sortOrder)}`
+	);
 
 	let deleteAction: string | null = $state(null);
 
@@ -135,6 +142,15 @@
 	backHref="/tests/test-session"
 	showInfoIcon={false}
 >
+	{#snippet headerActions()}
+		<a href={resolve(exportHref as any)} download>
+			<Button variant="outline" class="border-primary text-primary bg-card font-semibold">
+				<Download class="h-4 w-4" />
+				Export
+			</Button>
+		</a>
+	{/snippet}
+
 	{#snippet toolbar()}
 		{#if userCanDelete}
 			<BatchActionsToolbar

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/export/+server.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/export/+server.ts
@@ -1,0 +1,35 @@
+import { BACKEND_URL } from '$env/static/private';
+import { getSessionTokenCookie, requireLogin } from '$lib/server/auth';
+import { requirePermission, PERMISSIONS } from '$lib/utils/permissions.js';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ params, url }) => {
+	const user = requireLogin();
+	requirePermission(user, PERMISSIONS.READ_TEST);
+	const token = getSessionTokenCookie();
+
+	const sortBy = url.searchParams.get('sortBy') || '';
+	const sortOrder = url.searchParams.get('sortOrder') || 'asc';
+
+	const queryParams = new URLSearchParams({
+		...(sortBy && { sort_by: sortBy, sort_order: sortOrder })
+	});
+
+	const res = await fetch(
+		`${BACKEND_URL}/test/${params.id}/candidate-report/export?${queryParams}`,
+		{ headers: { Authorization: `Bearer ${token}` } }
+	);
+
+	if (!res.ok) {
+		return new Response('Failed to export responses', { status: res.status });
+	}
+
+	const headers = new Headers();
+	const contentType = res.headers.get('Content-Type');
+	const contentDisposition = res.headers.get('Content-Disposition');
+
+	if (contentType) headers.set('Content-Type', contentType);
+	headers.set('Content-Disposition', contentDisposition ?? 'attachment; filename="responses.csv"');
+
+	return new Response(res.body, { headers });
+};

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
@@ -99,14 +99,18 @@ const sampleResponses: CandidateResponse[] = [submittedCandidate, notSubmittedCa
 
 function makeData(
 	items: CandidateResponse[] = sampleResponses,
-	{ canDelete = false, testName = 'Sample Test' }: { canDelete?: boolean; testName?: string } = {}
+	{
+		canDelete = false,
+		testName = 'Sample Test',
+		params = {}
+	}: { canDelete?: boolean; testName?: string; params?: Record<string, unknown> } = {}
 ) {
 	return {
 		testId: '1',
 		testName,
 		responses: { items, total: items.length, pages: items.length > 0 ? 1 : 0 },
 		totalPages: items.length > 0 ? 1 : 0,
-		params: { page: 1, size: 25 },
+		params: { page: 1, size: 25, ...params },
 		user: { id: 1, permissions: canDelete ? ['delete_candidate'] : [] }
 	};
 }
@@ -145,6 +149,58 @@ describe('Candidate Responses page (UI)', () => {
 				'href',
 				'/tests/test-session'
 			);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	describe('Export button (headerActions)', () => {
+		it('shows the Export button when there are responses', () => {
+			render(ResponsesPage, { data: makeData(sampleResponses) } as any);
+			expect(screen.getByRole('link', { name: /Export/ })).toBeInTheDocument();
+		});
+
+		it('does not show the Export button when there are no responses', () => {
+			render(ResponsesPage, { data: makeData([]) } as any);
+			expect(screen.queryByRole('link', { name: /Export/ })).not.toBeInTheDocument();
+			expect(screen.queryByText('Export')).not.toBeInTheDocument();
+		});
+
+		it('shows the Export button again once responses come back after being empty', async () => {
+			const { rerender } = render(ResponsesPage, { data: makeData([]) } as any);
+			expect(screen.queryByRole('link', { name: /Export/ })).not.toBeInTheDocument();
+
+			await rerender({ data: makeData(sampleResponses) } as any);
+
+			expect(screen.getByRole('link', { name: /Export/ })).toBeInTheDocument();
+		});
+
+		it('renders the Export link with a download attribute', () => {
+			render(ResponsesPage, { data: makeData(sampleResponses) } as any);
+			expect(screen.getByRole('link', { name: /Export/ })).toHaveAttribute('download');
+		});
+
+		it('points the Export link at the export endpoint for the current test', () => {
+			render(ResponsesPage, { data: makeData(sampleResponses) } as any);
+			const href = screen.getByRole('link', { name: /Export/ }).getAttribute('href');
+			expect(href).toContain('/tests/test-standard/1/responses/export');
+		});
+
+		it('includes the current sortBy and sortOrder in the Export link', () => {
+			render(ResponsesPage, {
+				data: makeData(sampleResponses, { params: { sortBy: 'marks', sortOrder: 'desc' } })
+			} as any);
+
+			const href = screen.getByRole('link', { name: /Export/ }).getAttribute('href');
+			expect(href).toContain('sortBy=marks');
+			expect(href).toContain('sortOrder=desc');
+		});
+
+		it('defaults sortOrder to asc and sortBy to empty in the Export link when unsorted', () => {
+			render(ResponsesPage, { data: makeData(sampleResponses) } as any);
+
+			const href = screen.getByRole('link', { name: /Export/ }).getAttribute('href');
+			expect(href).toContain('sortBy=');
+			expect(href).toContain('sortOrder=asc');
 		});
 	});
 


### PR DESCRIPTION
fixes: #571 
depends:- https://github.com/sashakt-platform/sashakt-core/pull/569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an **Export** action on test response pages when responses exist.
  * Export downloads responses as a CSV and preserves the selected sorting options.
  * Export access requires authentication and the appropriate permissions.
* **Tests**
  * Added coverage for Export visibility, downloads, endpoint targeting, and sorting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->