### PR TITLE
Update placeholder for config JSON textarea based on edit mode

### DIFF
--- a/src/routes/(admin)/organization/integrations/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/organization/integrations/[action]/[id]/+page.svelte
@@ -126,7 +126,9 @@
 											{...props}
 											rows={10}
 											class="font-mono text-xs"
-											placeholder={`{\n  "type": "service_account",\n  "project_id": "your-project-id",\n  "private_key": "...",\n  "client_email": "..."\n}`}
+											placeholder={isEdit
+											? ''
+											: `{\n  "type": "service_account",\n  "project_id": "your-project-id",\n  "private_key": "...",\n  "client_email": "..."\n}`}
 											bind:value={$formData.config_json}
 										/>
 									{/snippet}

--- a/src/routes/(admin)/organization/integrations/[action]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/organization/integrations/[action]/[id]/page.svelte.test.ts
@@ -265,4 +265,27 @@ describe('Edit Provider Page (+page.svelte)', () => {
 		render(AddProviderPage, { data: makeEditData() } as never);
 		expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
 	});
+
+	describe('Config JSON textarea', () => {
+		it('does not show the service-account JSON placeholder', () => {
+			const { container } = render(AddProviderPage, { data: makeEditData() } as never);
+			const textarea = container.querySelector('textarea');
+			expect(textarea).not.toBeNull();
+			expect(textarea).toHaveAttribute('placeholder', '');
+			expect(screen.queryByPlaceholderText(/service_account/)).not.toBeInTheDocument();
+		});
+
+		it('still allows typing a new config value with no placeholder present', async () => {
+			const { container } = render(AddProviderPage, { data: makeEditData() } as never);
+			const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+			await fireEvent.input(textarea, { target: { value: '{"a":1}' } });
+			expect(textarea).toHaveValue('{"a":1}');
+		});
+
+		it('leaves the textarea empty when config_json is not pre-filled in edit mode', () => {
+			const { container } = render(AddProviderPage, { data: makeEditData() } as never);
+			const textarea = container.querySelector('textarea');
+			expect(textarea).toHaveValue('');
+		});
+	});
 });


### PR DESCRIPTION
fixes : #587  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Configuration JSON field so its placeholder is blank when editing an existing integration, allowing users to retain the current configuration without confusion.
  * New integrations continue to display the default service-account JSON template.

* **Tests**
  * Added coverage confirming edit-mode placeholder and input behavior, including integrations without pre-filled configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->