### PR TITLE
Org level roles permissions

### DIFF
--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -82,6 +82,9 @@
 		if (hasPermission(data.user, PERMISSIONS.UPDATE_MY_ORGANIZATION)) {
 			children.push({ title: 'Integrations', url: '/organization/integrations' });
 		}
+		if (hasPermission(data.user, PERMISSIONS.READ_ROLE)) {
+			children.push({ title: 'Roles and Permission', url: '/organization/roles-permissions' });
+		}
 		return children;
 	});
 

--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -9,8 +9,7 @@
 	import Briefcase from '@lucide/svelte/icons/briefcase';
 	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import {
-		canCreate,
-		canUpdate,
+		canRead,
 		hasAnyPermission,
 		hasPermission,
 		isSuperAdmin,
@@ -141,7 +140,7 @@
 			<Sidebar.GroupContent class="text-base leading-1">
 				<Sidebar.Menu>
 					{#each menu_items as item (item.url)}
-						{#if (!item.entity || canCreate(data.user, item.entity) || canUpdate(data.user, item.entity)) && (!superAdmin || item.entity === 'user' || item.entity === 'organization')}
+						{#if (!item.entity || canRead(data.user, item.entity)) && (!superAdmin || item.entity === 'user' || item.entity === 'organization')}
 							{@render sidebaritems(item)}
 						{/if}
 					{/each}

--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -79,7 +79,7 @@
 		) {
 			children.push({ title: 'Organisation Settings', url: '/organization/settings' });
 		}
-		if (hasPermission(data.user, PERMISSIONS.UPDATE_MY_ORGANIZATION)) {
+		if (hasPermission(data.user, PERMISSIONS.READ_PROVIDER)) {
 			children.push({ title: 'Integrations', url: '/organization/integrations' });
 		}
 		if (hasPermission(data.user, PERMISSIONS.READ_ROLE)) {

--- a/src/lib/components/app-sidebar.svelte.test.ts
+++ b/src/lib/components/app-sidebar.svelte.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import AppSidebar from './app-sidebar.svelte';
-import { isSuperAdmin } from '$lib/utils/permissions.js';
+import { hasPermission, isSuperAdmin } from '$lib/utils/permissions.js';
 import { setCustomNomenclature, resetNomenclature } from '$lib/test-utils/nomenclature-mock';
 
 vi.mock('$app/navigation', () => ({
@@ -343,5 +343,47 @@ describe('AppSidebar - Platform Guide PDF', () => {
 		});
 
 		expect(screen.queryByText('Platform Guide PDF')).not.toBeInTheDocument();
+	});
+});
+
+describe('AppSidebar - My Organisation submenu', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(isSuperAdmin).mockReturnValue(false);
+	});
+
+	it('shows "Roles and Permission" link when the user has READ_ROLE permission', () => {
+		vi.mocked(hasPermission).mockReturnValue(true);
+
+		render(AppSidebar, { data: baseData });
+
+		const link = screen.getByText('Roles and Permission').closest('a');
+		expect(link).toHaveAttribute('href', '/organization/roles-permissions');
+	});
+
+	it('hides "Roles and Permission" link when the user lacks any My Organisation permission', () => {
+		vi.mocked(hasPermission).mockReturnValue(false);
+
+		render(AppSidebar, { data: baseData });
+
+		expect(screen.queryByText('Roles and Permission')).not.toBeInTheDocument();
+	});
+
+	it('places "Roles and Permission" after "Integrations" in the submenu', () => {
+		vi.mocked(hasPermission).mockReturnValue(true);
+
+		render(AppSidebar, { data: baseData });
+
+		const items = screen.getAllByText(/Integrations|Roles and Permission/);
+		expect(items.map((el) => el.textContent)).toEqual(['Integrations', 'Roles and Permission']);
+	});
+
+	it('does not show "Roles and Permission" for a super admin', () => {
+		vi.mocked(isSuperAdmin).mockReturnValue(true);
+		vi.mocked(hasPermission).mockReturnValue(true);
+
+		render(AppSidebar, { data: baseData });
+
+		expect(screen.queryByText('Roles and Permission')).not.toBeInTheDocument();
 	});
 });

--- a/src/routes/(admin)/organization/+page.server.ts
+++ b/src/routes/(admin)/organization/+page.server.ts
@@ -2,6 +2,7 @@ import { BACKEND_URL } from '$env/static/private';
 import {
 	getSessionTokenCookie,
 	organizationCookieName,
+	requireLogin,
 	setOrganizationCookie
 } from '$lib/server/auth.js';
 import { invalidateOrganizationCache } from '$lib/server/organization-cache.js';
@@ -11,6 +12,7 @@ import { superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 import type { Actions, PageServerLoad } from './$types.js';
 import { editOrganizationSchema } from './schema.js';
+import { requirePermission, PERMISSIONS } from '$lib/utils/permissions.js';
 
 async function fetchOrganizationSettings(
 	fetchFn: typeof fetch,
@@ -46,6 +48,9 @@ function deriveFilename(url: string | null): string | null {
 }
 
 export const load: PageServerLoad = async ({ fetch, locals }) => {
+	const user = requireLogin();
+	requirePermission(user, PERMISSIONS.UPDATE_MY_ORGANIZATION);
+
 	const token = getSessionTokenCookie();
 	let organizationData = null;
 
@@ -90,6 +95,9 @@ export const load: PageServerLoad = async ({ fetch, locals }) => {
 
 export const actions: Actions = {
 	save: async ({ request, fetch, cookies, locals }) => {
+		const user = requireLogin();
+		requirePermission(user, PERMISSIONS.UPDATE_MY_ORGANIZATION);
+
 		const token = getSessionTokenCookie();
 
 		const form = await superValidate(request, zod4(editOrganizationSchema));

--- a/src/routes/(admin)/organization/page.server.test.ts
+++ b/src/routes/(admin)/organization/page.server.test.ts
@@ -46,9 +46,17 @@ vi.mock('sveltekit-superforms', () => ({
 
 // Mock auth functions
 vi.mock('$lib/server/auth.js', () => ({
+	requireLogin: vi.fn(() => ({ id: 1, organization_id: 10, permissions: ['update_my_organization'] })),
 	getSessionTokenCookie: vi.fn(() => 'mock-token'),
 	organizationCookieName: 'sashakt-organization',
 	setOrganizationCookie: vi.fn()
+}));
+
+vi.mock('$lib/utils/permissions.js', () => ({
+	requirePermission: vi.fn(),
+	PERMISSIONS: {
+		UPDATE_MY_ORGANIZATION: 'update_my_organization'
+	}
 }));
 
 // Mock organization cache

--- a/src/routes/(admin)/organization/roles-permissions/+page.server.ts
+++ b/src/routes/(admin)/organization/roles-permissions/+page.server.ts
@@ -1,0 +1,10 @@
+import { requireLogin } from '$lib/server/auth';
+import { requirePermission, PERMISSIONS } from '$lib/utils/permissions.js';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	const user = requireLogin();
+	requirePermission(user, PERMISSIONS.READ_ROLE);
+
+	return {};
+};

--- a/src/routes/(admin)/organization/roles-permissions/+page.server.ts
+++ b/src/routes/(admin)/organization/roles-permissions/+page.server.ts
@@ -1,10 +1,34 @@
-import { requireLogin } from '$lib/server/auth';
+import { BACKEND_URL } from '$env/static/private';
+import { getSessionTokenCookie, requireLogin } from '$lib/server/auth';
 import { requirePermission, PERMISSIONS } from '$lib/utils/permissions.js';
+import { setFlash } from 'sveltekit-flash-message/server';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ cookies }) => {
 	const user = requireLogin();
 	requirePermission(user, PERMISSIONS.READ_ROLE);
+	const token = getSessionTokenCookie();
 
-	return {};
+	const res = await fetch(`${BACKEND_URL}/roles/`, {
+		method: 'GET',
+		headers: { Authorization: `Bearer ${token}` }
+	});
+
+	if (!res.ok) {
+		const errorMessage = await res.json();
+
+		setFlash(
+			{
+				type: 'error',
+				message: `Failed to fetch roles: ${errorMessage.detail || res.statusText}`
+			},
+			cookies
+		);
+
+		return { roles: [] };
+	}
+
+	const { data: roles } = await res.json();
+
+	return { roles };
 };

--- a/src/routes/(admin)/organization/roles-permissions/+page.svelte
+++ b/src/routes/(admin)/organization/roles-permissions/+page.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
+	import { DataTable } from '$lib/components/data-table';
 	import ListingPageLayout from '$lib/components/ListingPageLayout.svelte';
+	import { createColumns } from './columns';
+
+	let { data } = $props();
+
+	const tableData = $derived(data?.roles || []);
+	const totalItems = $derived(tableData.length);
+	const totalPages = 1;
+	const currentPage = 1;
+	const pageSize = $derived(Math.max(tableData.length, 1));
+
+	const columns = createColumns();
 </script>
 
-<ListingPageLayout
-	title="Roles and Permission"
-	subtitle=""
-	showInfoIcon={false}
-	showEmptyState={true}
->
-	{#snippet emptyState()}
-		<div class="flex flex-1 flex-col items-center justify-center gap-2 py-24 text-center">
-			<h3 class="text-lg font-semibold">Coming soon</h3>
-			<p class="text-muted-foreground text-sm">Roles and permission management is on its way.</p>
-		</div>
+<ListingPageLayout title="Roles and Permission" subtitle="" showInfoIcon={false}>
+	{#snippet content()}
+		<DataTable data={tableData} {columns} {totalItems} {totalPages} {currentPage} {pageSize} />
 	{/snippet}
 </ListingPageLayout>

--- a/src/routes/(admin)/organization/roles-permissions/+page.svelte
+++ b/src/routes/(admin)/organization/roles-permissions/+page.svelte
@@ -2,6 +2,7 @@
 	import { DataTable } from '$lib/components/data-table';
 	import ListingPageLayout from '$lib/components/ListingPageLayout.svelte';
 	import { createColumns } from './columns';
+	import { canUpdate } from '$lib/utils/permissions.js';
 
 	let { data } = $props();
 
@@ -11,7 +12,7 @@
 	const currentPage = 1;
 	const pageSize = $derived(Math.max(tableData.length, 1));
 
-	const columns = createColumns();
+	const columns = $derived(createColumns({ canEdit: canUpdate(data.user, 'role') }));
 </script>
 
 <ListingPageLayout title="Roles and Permission" subtitle="" showInfoIcon={false}>

--- a/src/routes/(admin)/organization/roles-permissions/+page.svelte
+++ b/src/routes/(admin)/organization/roles-permissions/+page.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import ListingPageLayout from '$lib/components/ListingPageLayout.svelte';
+</script>
+
+<ListingPageLayout
+	title="Roles and Permission"
+	subtitle=""
+	showInfoIcon={false}
+	showEmptyState={true}
+>
+	{#snippet emptyState()}
+		<div class="flex flex-1 flex-col items-center justify-center gap-2 py-24 text-center">
+			<h3 class="text-lg font-semibold">Coming soon</h3>
+			<p class="text-muted-foreground text-sm">Roles and permission management is on its way.</p>
+		</div>
+	{/snippet}
+</ListingPageLayout>

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.server.ts
@@ -1,30 +1,105 @@
 import { BACKEND_URL } from '$env/static/private';
 import { getSessionTokenCookie, requireLogin } from '$lib/server/auth';
 import { requirePermission, PERMISSIONS } from '$lib/utils/permissions.js';
-import { error } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
+import { error, fail } from '@sveltejs/kit';
+import { setFlash } from 'sveltekit-flash-message/server';
+import type { PageServerLoad, Actions } from './$types';
 
-export const load: PageServerLoad = async ({ params }) => {
+type Role = {
+	id: number;
+	organization_id: number;
+	name: string;
+	label: string;
+	description: string | null;
+	is_active: boolean;
+	permissions: number[];
+};
+
+type Permission = {
+	id: number;
+	name: string;
+	description: string | null;
+	is_active: boolean;
+};
+
+export const load: PageServerLoad = async ({ params, cookies }) => {
 	const user = requireLogin();
 	requirePermission(user, PERMISSIONS.UPDATE_ROLE);
 	const token = getSessionTokenCookie();
 
-	const res = await fetch(`${BACKEND_URL}/roles/`, {
+	const roleRes = await fetch(`${BACKEND_URL}/roles/${params.id}`, {
 		method: 'GET',
 		headers: { Authorization: `Bearer ${token}` }
 	});
 
-	if (!res.ok) {
-		const errorMessage = await res.json();
-		error(res.status, errorMessage.detail || 'Failed to load role');
+	if (!roleRes.ok) {
+		const errorMessage = await roleRes.json();
+		error(roleRes.status, errorMessage.detail || 'Failed to load role');
 	}
 
-	const { data: roles } = await res.json();
-	const role = roles.find((r: { id: number }) => String(r.id) === params.id);
+	const role: Role = await roleRes.json();
 
-	if (!role) {
-		error(404, 'Role not found');
+	let permissionCatalog: Permission[] = [];
+	const permissionsRes = await fetch(`${BACKEND_URL}/permissions/?limit=500`, {
+		method: 'GET',
+		headers: { Authorization: `Bearer ${token}` }
+	});
+
+	if (permissionsRes.ok) {
+		const body = await permissionsRes.json();
+		permissionCatalog = body.data;
+	} else {
+		setFlash(
+			{
+				type: 'error',
+				message: 'Unable to load the permission catalog. You can still view the role name.'
+			},
+			cookies
+		);
 	}
 
-	return { role };
+	return { role, permissionCatalog };
+};
+
+export const actions: Actions = {
+	save: async ({ request, params, cookies }) => {
+		const user = requireLogin();
+		requirePermission(user, PERMISSIONS.UPDATE_ROLE);
+		const token = getSessionTokenCookie();
+
+		const formData = await request.formData();
+		const name = formData.get('name');
+		const label = formData.get('label');
+		const description = formData.get('description');
+		const isActive = formData.get('is_active') === 'true';
+		const permissions = formData.getAll('permissions').map((id) => Number(id));
+
+		if (typeof name !== 'string' || typeof label !== 'string') {
+			return fail(400, { message: 'Missing role data' });
+		}
+
+		const res = await fetch(`${BACKEND_URL}/roles/${params.id}`, {
+			method: 'PUT',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${token}`
+			},
+			body: JSON.stringify({
+				name,
+				label,
+				description: typeof description === 'string' && description ? description : null,
+				is_active: isActive,
+				permissions
+			})
+		});
+
+		if (!res.ok) {
+			const errorMessage = await res.json();
+			setFlash({ type: 'error', message: errorMessage.detail || 'Failed to update role' }, cookies);
+			return fail(res.status, { message: errorMessage.detail || 'Failed to update role' });
+		}
+
+		setFlash({ type: 'success', message: 'Role updated successfully' }, cookies);
+		return { success: true };
+	}
 };

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.server.ts
@@ -1,0 +1,30 @@
+import { BACKEND_URL } from '$env/static/private';
+import { getSessionTokenCookie, requireLogin } from '$lib/server/auth';
+import { requirePermission, PERMISSIONS } from '$lib/utils/permissions.js';
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params }) => {
+	const user = requireLogin();
+	requirePermission(user, PERMISSIONS.UPDATE_ROLE);
+	const token = getSessionTokenCookie();
+
+	const res = await fetch(`${BACKEND_URL}/roles/`, {
+		method: 'GET',
+		headers: { Authorization: `Bearer ${token}` }
+	});
+
+	if (!res.ok) {
+		const errorMessage = await res.json();
+		error(res.status, errorMessage.detail || 'Failed to load role');
+	}
+
+	const { data: roles } = await res.json();
+	const role = roles.find((r: { id: number }) => String(r.id) === params.id);
+
+	if (!role) {
+		error(404, 'Role not found');
+	}
+
+	return { role };
+};

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.server.ts
@@ -2,7 +2,7 @@ import { BACKEND_URL } from '$env/static/private';
 import { getSessionTokenCookie, requireLogin } from '$lib/server/auth';
 import { requirePermission, PERMISSIONS } from '$lib/utils/permissions.js';
 import { error, fail } from '@sveltejs/kit';
-import { setFlash } from 'sveltekit-flash-message/server';
+import { redirect, setFlash } from 'sveltekit-flash-message/server';
 import type { PageServerLoad, Actions } from './$types';
 
 type Role = {
@@ -99,7 +99,11 @@ export const actions: Actions = {
 			return fail(res.status, { message: errorMessage.detail || 'Failed to update role' });
 		}
 
-		setFlash({ type: 'success', message: 'Role updated successfully' }, cookies);
-		return { success: true };
+		redirect(
+			303,
+			`/organization/roles-permissions/edit/${params.id}`,
+			{ type: 'success', message: 'Role updated successfully' },
+			cookies
+		);
 	}
 };

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+	import { resolve } from '$app/paths';
+	import { Input } from '$lib/components/ui/input/index.js';
+
+	let { data } = $props();
+</script>
+
+<div>
+	<div class="bg-card">
+		<div class="mx-4 flex items-center justify-between py-4 sm:mx-10">
+			<div class="m-4 flex items-center gap-3">
+				<a
+					href={resolve('/organization/roles-permissions')}
+					class="border-border hover:bg-muted rounded-lg border p-2"
+					aria-label="Back to Roles and Permission"
+				>
+					<ArrowLeft size={20} />
+				</a>
+				<h2 class="text-2xl font-bold tracking-tight">Edit Role</h2>
+			</div>
+		</div>
+	</div>
+	<hr class="border-border" />
+
+	<div class="bg-background">
+		<div class="mx-4 mt-6 flex flex-col gap-8 sm:mx-8 sm:mt-10">
+			<div
+				class="bg-card border-border flex flex-col items-center justify-between gap-4 rounded-2xl border p-6 sm:flex-row"
+			>
+				<div>
+					<p class="font-semibold">Role name</p>
+					<p class="text-muted-foreground text-sm">Predefined roles can't be renamed</p>
+				</div>
+				<Input value={data.role.label} disabled class="bg-muted max-w-md" />
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.svelte
@@ -20,6 +20,30 @@
 			.join(' ');
 	}
 
+	const HIDDEN_RESOURCES = new Set([
+		'user_me',
+		'question_location',
+		'question_revision',
+		'question_tag',
+		'organization',
+		'organization_settings',
+		'candidate_test',
+		'candidate_test_answer',
+		'form_response',
+		'location'
+	]);
+
+	const PARTIAL_HIDDEN_ACTIONS: Partial<Record<string, Action[]>> = {
+		candidate: ['create', 'read', 'update'],
+		user: ['read']
+	};
+
+	const RESOURCE_LABEL_OVERRIDES: Record<string, string> = {
+		provider: 'Integrations',
+		my_organization: 'Organization',
+		my_organization_settings: 'Organization Settings'
+	};
+
 	const permissionGroups = $derived.by(() => {
 		const permissionsByResource: Record<string, Partial<Record<Action, Permission>>> = {};
 
@@ -27,6 +51,8 @@
 			const match = permission.name.match(/^(create|read|update|delete)_(.+)$/);
 			if (!match) continue;
 			const [, action, resource] = match;
+			if (HIDDEN_RESOURCES.has(resource)) continue;
+			if (PARTIAL_HIDDEN_ACTIONS[resource]?.includes(action as Action)) continue;
 			permissionsByResource[resource] ??= {};
 			permissionsByResource[resource][action as Action] = permission;
 		}
@@ -34,7 +60,7 @@
 		return Object.entries(permissionsByResource)
 			.map(([resource, permissionsByAction]) => ({
 				resource,
-				label: humanize(resource),
+				label: RESOURCE_LABEL_OVERRIDES[resource] ?? humanize(resource),
 				permissionsByAction
 			}))
 			.sort((firstGroup, secondGroup) => firstGroup.label.localeCompare(secondGroup.label));

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.svelte
@@ -98,37 +98,40 @@
 						</div>
 					{:else}
 						<div class="bg-card border-border overflow-hidden rounded-2xl border">
+							<div
+								class="bg-muted text-muted-foreground flex items-center justify-between px-6 py-5 text-xs font-bold tracking-wide uppercase"
+							>
+								<p>Permission</p>
+								<div class="flex gap-8">
+									{#each ACTIONS as action (action)}
+										<span class="w-14 text-center">{action}</span>
+									{/each}
+								</div>
+							</div>
 							{#each permissionGroups as permissionGroup, groupIndex (permissionGroup.resource)}
-								<div class={groupIndex > 0 ? 'border-border border-t' : ''}>
-									<div class="flex items-center justify-between px-6 py-4">
-										<p class="font-semibold">{permissionGroup.label}</p>
-										<div
-											class="text-muted-foreground flex gap-8 text-xs font-bold tracking-wide uppercase"
-										>
-											{#each ACTIONS as action (action)}
-												<span class="w-14 text-center">{action}</span>
-											{/each}
-										</div>
-									</div>
-									<div class="border-border flex items-center justify-between border-t px-6 py-4">
-										<p class="text-sm">{permissionGroup.label}</p>
-										<div class="flex gap-8">
-											{#each ACTIONS as action (action)}
-												<div class="flex w-14 justify-center">
-													{#if permissionGroup.permissionsByAction[action]}
-														<Switch
-															checked={selectedIds.has(
-																permissionGroup.permissionsByAction[action]!.id
-															)}
-															onCheckedChange={(checked) =>
-																toggle(permissionGroup.permissionsByAction[action]!.id, checked)}
-														/>
-													{:else}
-														<span class="text-muted-foreground">—</span>
-													{/if}
-												</div>
-											{/each}
-										</div>
+								<div
+									class={[
+										'flex items-center justify-between px-6 py-4',
+										groupIndex > 0 && 'border-border border-t'
+									]}
+								>
+									<p class="text-sm">{permissionGroup.label}</p>
+									<div class="flex gap-8">
+										{#each ACTIONS as action (action)}
+											<div class="flex w-14 justify-center">
+												{#if permissionGroup.permissionsByAction[action]}
+													<Switch
+														checked={selectedIds.has(
+															permissionGroup.permissionsByAction[action]!.id
+														)}
+														onCheckedChange={(checked) =>
+															toggle(permissionGroup.permissionsByAction[action]!.id, checked)}
+													/>
+												{:else}
+													<span class="text-muted-foreground">—</span>
+												{/if}
+											</div>
+										{/each}
 									</div>
 								</div>
 							{/each}

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.svelte
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/+page.svelte
@@ -1,9 +1,64 @@
 <script lang="ts">
 	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import { resolve } from '$app/paths';
-	import { Input } from '$lib/components/ui/input/index.js';
+	import { enhance } from '$app/forms';
+	import { SvelteSet } from 'svelte/reactivity';
+	import { Switch } from '$lib/components/ui/switch/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 
 	let { data } = $props();
+
+	const ACTIONS = ['create', 'read', 'update', 'delete'] as const;
+	type Action = (typeof ACTIONS)[number];
+
+	type Permission = { id: number; name: string; description: string | null; is_active: boolean };
+
+	function humanize(resource: string): string {
+		return resource
+			.split('_')
+			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+			.join(' ');
+	}
+
+	const permissionGroups = $derived.by(() => {
+		const permissionsByResource: Record<string, Partial<Record<Action, Permission>>> = {};
+
+		for (const permission of data.permissionCatalog as Permission[]) {
+			const match = permission.name.match(/^(create|read|update|delete)_(.+)$/);
+			if (!match) continue;
+			const [, action, resource] = match;
+			permissionsByResource[resource] ??= {};
+			permissionsByResource[resource][action as Action] = permission;
+		}
+
+		return Object.entries(permissionsByResource)
+			.map(([resource, permissionsByAction]) => ({
+				resource,
+				label: humanize(resource),
+				permissionsByAction
+			}))
+			.sort((firstGroup, secondGroup) => firstGroup.label.localeCompare(secondGroup.label));
+	});
+
+	const selectedIds = new SvelteSet<number>(data.role.permissions);
+	const initialIds = $derived(new Set<number>(data.role.permissions));
+
+	$effect(() => {
+		selectedIds.clear();
+		for (const id of data.role.permissions) selectedIds.add(id);
+	});
+
+	const canSave = $derived(
+		selectedIds.size !== initialIds.size || [...selectedIds].some((id) => !initialIds.has(id))
+	);
+
+	function toggle(permissionId: number, checked: boolean) {
+		if (checked) {
+			selectedIds.add(permissionId);
+		} else {
+			selectedIds.delete(permissionId);
+		}
+	}
 </script>
 
 <div>
@@ -17,23 +72,79 @@
 				>
 					<ArrowLeft size={20} />
 				</a>
-				<h2 class="text-2xl font-bold tracking-tight">Edit Role</h2>
+				<h2 class="text-2xl font-bold tracking-tight">Edit {data.role.label}</h2>
 			</div>
 		</div>
 	</div>
 	<hr class="border-border" />
 
-	<div class="bg-background">
-		<div class="mx-4 mt-6 flex flex-col gap-8 sm:mx-8 sm:mt-10">
-			<div
-				class="bg-card border-border flex flex-col items-center justify-between gap-4 rounded-2xl border p-6 sm:flex-row"
-			>
-				<div>
-					<p class="font-semibold">Role name</p>
-					<p class="text-muted-foreground text-sm">Predefined roles can't be renamed</p>
+	<form method="POST" action="?/save" use:enhance>
+		<input type="hidden" name="name" value={data.role.name} />
+		<input type="hidden" name="label" value={data.role.label} />
+		<input type="hidden" name="description" value={data.role.description ?? ''} />
+		<input type="hidden" name="is_active" value={String(data.role.is_active)} />
+		{#each selectedIds as id (id)}
+			<input type="hidden" name="permissions" value={id} />
+		{/each}
+
+		<div class="bg-background">
+			<div class="mx-4 mt-6 flex flex-col gap-8 sm:mx-8 sm:mt-10">
+				<div class="flex flex-col gap-4">
+					{#if data.permissionCatalog.length === 0}
+						<div class="bg-card border-border rounded-2xl border p-8 text-center">
+							<p class="text-muted-foreground text-sm">
+								The permission catalog couldn't be loaded, so permissions can't be edited right now.
+							</p>
+						</div>
+					{:else}
+						<div class="bg-card border-border overflow-hidden rounded-2xl border">
+							{#each permissionGroups as permissionGroup, groupIndex (permissionGroup.resource)}
+								<div class={groupIndex > 0 ? 'border-border border-t' : ''}>
+									<div class="flex items-center justify-between px-6 py-4">
+										<p class="font-semibold">{permissionGroup.label}</p>
+										<div
+											class="text-muted-foreground flex gap-8 text-xs font-bold tracking-wide uppercase"
+										>
+											{#each ACTIONS as action (action)}
+												<span class="w-14 text-center">{action}</span>
+											{/each}
+										</div>
+									</div>
+									<div class="border-border flex items-center justify-between border-t px-6 py-4">
+										<p class="text-sm">{permissionGroup.label}</p>
+										<div class="flex gap-8">
+											{#each ACTIONS as action (action)}
+												<div class="flex w-14 justify-center">
+													{#if permissionGroup.permissionsByAction[action]}
+														<Switch
+															checked={selectedIds.has(
+																permissionGroup.permissionsByAction[action]!.id
+															)}
+															onCheckedChange={(checked) =>
+																toggle(permissionGroup.permissionsByAction[action]!.id, checked)}
+														/>
+													{:else}
+														<span class="text-muted-foreground">—</span>
+													{/if}
+												</div>
+											{/each}
+										</div>
+									</div>
+								</div>
+							{/each}
+						</div>
+					{/if}
 				</div>
-				<Input value={data.role.label} disabled class="bg-muted max-w-md" />
 			</div>
 		</div>
-	</div>
+
+		<div class="bg-card border-border sticky bottom-0 border-t">
+			<div class="mx-4 flex justify-end gap-3 py-4 sm:mx-10">
+				<a href={resolve('/organization/roles-permissions')}>
+					<Button type="button" variant="outline">Cancel</Button>
+				</a>
+				<Button type="submit" disabled={!canSave}>Save</Button>
+			</div>
+		</div>
+	</form>
 </div>

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/page.server.test.ts
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/page.server.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as server from './+page.server';
-import { setFlash } from 'sveltekit-flash-message/server';
+import { redirect, setFlash } from 'sveltekit-flash-message/server';
 
 vi.mock('$env/static/private', () => ({
 	BACKEND_URL: 'http://fake-backend'
@@ -19,7 +19,8 @@ vi.mock('$lib/utils/permissions.js', () => ({
 }));
 
 vi.mock('sveltekit-flash-message/server', () => ({
-	setFlash: vi.fn()
+	setFlash: vi.fn(),
+	redirect: vi.fn()
 }));
 
 const mockCookies = {
@@ -257,20 +258,21 @@ describe('page.server save action', () => {
 		expect(body.permissions).toEqual([]);
 	});
 
-	it('sets a success flash and returns success without redirecting', async () => {
+	it('redirects to the same edit page with a success flash', async () => {
 		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
-		const result = (await server.actions.save({
+		await server.actions.save({
 			request: makeFormData(),
 			params: { id: '2' },
 			cookies: mockCookies
-		} as any)) as any;
+		} as any);
 
-		expect(setFlash).toHaveBeenCalledWith(
+		expect(redirect).toHaveBeenCalledWith(
+			303,
+			'/organization/roles-permissions/edit/2',
 			{ type: 'success', message: 'Role updated successfully' },
 			mockCookies
 		);
-		expect(result).toEqual({ success: true });
 	});
 
 	it('returns fail with the backend detail when the PUT fails', async () => {

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/page.server.test.ts
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/page.server.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as server from './+page.server';
+import { setFlash } from 'sveltekit-flash-message/server';
+
+vi.mock('$env/static/private', () => ({
+	BACKEND_URL: 'http://fake-backend'
+}));
+
+vi.mock('$lib/server/auth', () => ({
+	requireLogin: vi.fn(() => ({ id: 1, organization_id: 10, permissions: ['update_role'] })),
+	getSessionTokenCookie: vi.fn(() => 'fake-token')
+}));
+
+vi.mock('$lib/utils/permissions.js', () => ({
+	requirePermission: vi.fn(),
+	PERMISSIONS: {
+		UPDATE_ROLE: 'update_role'
+	}
+}));
+
+vi.mock('sveltekit-flash-message/server', () => ({
+	setFlash: vi.fn()
+}));
+
+const mockCookies = {
+	get: vi.fn(),
+	getAll: vi.fn(),
+	set: vi.fn(),
+	delete: vi.fn(),
+	serialize: vi.fn()
+};
+
+global.fetch = vi.fn();
+
+const mockRole = {
+	id: 2,
+	organization_id: 10,
+	name: 'test_admin',
+	label: 'Test Admin',
+	description: 'Test Admin role',
+	is_active: true,
+	permissions: [1, 2, 3]
+};
+
+const mockCatalog = {
+	data: [
+		{ id: 1, name: 'create_test', description: null, is_active: true },
+		{ id: 2, name: 'read_test', description: null, is_active: true }
+	],
+	count: 2
+};
+
+describe('page.server load function', () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	function mockRoleAndCatalogFetch() {
+		(global.fetch as any)
+			.mockResolvedValueOnce({ ok: true, json: async () => mockRole })
+			.mockResolvedValueOnce({ ok: true, json: async () => mockCatalog });
+	}
+
+	it('requires the UPDATE_ROLE permission', async () => {
+		const permissions = await import('$lib/utils/permissions.js');
+		mockRoleAndCatalogFetch();
+
+		await server.load({ params: { id: '2' }, cookies: mockCookies } as any);
+
+		expect(permissions.requirePermission).toHaveBeenCalledWith(
+			expect.objectContaining({ organization_id: 10 }),
+			'update_role'
+		);
+	});
+
+	it('fetches the role by id with the correct URL and Bearer token', async () => {
+		mockRoleAndCatalogFetch();
+
+		await server.load({ params: { id: '2' }, cookies: mockCookies } as any);
+
+		expect(global.fetch).toHaveBeenNthCalledWith(
+			1,
+			'http://fake-backend/roles/2',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({ Authorization: 'Bearer fake-token' })
+			})
+		);
+	});
+
+	it('fetches the permission catalog with the correct URL and Bearer token', async () => {
+		mockRoleAndCatalogFetch();
+
+		await server.load({ params: { id: '2' }, cookies: mockCookies } as any);
+
+		expect(global.fetch).toHaveBeenNthCalledWith(
+			2,
+			'http://fake-backend/permissions/?limit=500',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({ Authorization: 'Bearer fake-token' })
+			})
+		);
+	});
+
+	it('returns the role and permission catalog on success', async () => {
+		mockRoleAndCatalogFetch();
+
+		const result = (await server.load({ params: { id: '2' }, cookies: mockCookies } as any)) as any;
+
+		expect(result.role).toEqual(mockRole);
+		expect(result.permissionCatalog).toEqual(mockCatalog.data);
+	});
+
+	it('throws a load error with the backend detail when the role fetch fails', async () => {
+		(global.fetch as any).mockResolvedValueOnce({
+			ok: false,
+			status: 404,
+			json: async () => ({ detail: 'Role not found' })
+		});
+
+		await expect(
+			server.load({ params: { id: '999' }, cookies: mockCookies } as any)
+		).rejects.toMatchObject({ status: 404, body: { message: 'Role not found' } });
+	});
+
+	it('falls back to a default message when the role fetch fails without detail', async () => {
+		(global.fetch as any).mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			json: async () => ({})
+		});
+
+		await expect(
+			server.load({ params: { id: '2' }, cookies: mockCookies } as any)
+		).rejects.toMatchObject({ status: 500, body: { message: 'Failed to load role' } });
+	});
+
+	it('degrades gracefully with an empty catalog and an error flash when the permissions fetch fails', async () => {
+		(global.fetch as any)
+			.mockResolvedValueOnce({ ok: true, json: async () => mockRole })
+			.mockResolvedValueOnce({ ok: false, status: 401, json: async () => ({}) });
+
+		const result = (await server.load({ params: { id: '2' }, cookies: mockCookies } as any)) as any;
+
+		expect(result.role).toEqual(mockRole);
+		expect(result.permissionCatalog).toEqual([]);
+		expect(setFlash).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }), mockCookies);
+	});
+
+	it('does not throw the whole page when only the permissions fetch fails', async () => {
+		(global.fetch as any)
+			.mockResolvedValueOnce({ ok: true, json: async () => mockRole })
+			.mockResolvedValueOnce({ ok: false, status: 401, json: async () => ({}) });
+
+		await expect(
+			server.load({ params: { id: '2' }, cookies: mockCookies } as any)
+		).resolves.toBeDefined();
+	});
+});
+
+describe('page.server save action', () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	function makeFormData(overrides: Record<string, string | string[] | undefined> = {}) {
+		const fields: Record<string, string | string[] | undefined> = {
+			name: 'test_admin',
+			label: 'Test Admin',
+			description: 'Test Admin role',
+			is_active: 'true',
+			permissions: ['1', '2'],
+			...overrides
+		};
+		const formData = new FormData();
+		for (const [key, value] of Object.entries(fields)) {
+			if (value === undefined) continue;
+			if (Array.isArray(value)) {
+				value.forEach((v) => formData.append(key, v));
+			} else {
+				formData.append(key, value);
+			}
+		}
+		return { formData: async () => formData };
+	}
+
+	it('requires the UPDATE_ROLE permission', async () => {
+		const permissions = await import('$lib/utils/permissions.js');
+		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+		await server.actions.save({
+			request: makeFormData(),
+			params: { id: '2' },
+			cookies: mockCookies
+		} as any);
+
+		expect(permissions.requirePermission).toHaveBeenCalledWith(
+			expect.objectContaining({ organization_id: 10 }),
+			'update_role'
+		);
+	});
+
+	it('returns fail(400) when required role data is missing', async () => {
+		const result = (await server.actions.save({
+			request: makeFormData({ name: undefined }),
+			params: { id: '2' },
+			cookies: mockCookies
+		} as any)) as any;
+
+		expect(result.status).toBe(400);
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it('PUTs to the role endpoint with the full role payload', async () => {
+		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+		await server.actions.save({
+			request: makeFormData(),
+			params: { id: '2' },
+			cookies: mockCookies
+		} as any);
+
+		expect(global.fetch).toHaveBeenCalledWith(
+			'http://fake-backend/roles/2',
+			expect.objectContaining({ method: 'PUT' })
+		);
+		const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+		expect(body).toEqual({
+			name: 'test_admin',
+			label: 'Test Admin',
+			description: 'Test Admin role',
+			is_active: true,
+			permissions: [1, 2]
+		});
+	});
+
+	it('sends null description when description is blank', async () => {
+		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+		await server.actions.save({
+			request: makeFormData({ description: '' }),
+			params: { id: '2' },
+			cookies: mockCookies
+		} as any);
+
+		const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+		expect(body.description).toBeNull();
+	});
+
+	it('sends an empty permissions array when none are selected', async () => {
+		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+		await server.actions.save({
+			request: makeFormData({ permissions: [] }),
+			params: { id: '2' },
+			cookies: mockCookies
+		} as any);
+
+		const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+		expect(body.permissions).toEqual([]);
+	});
+
+	it('sets a success flash and returns success without redirecting', async () => {
+		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+		const result = (await server.actions.save({
+			request: makeFormData(),
+			params: { id: '2' },
+			cookies: mockCookies
+		} as any)) as any;
+
+		expect(setFlash).toHaveBeenCalledWith(
+			{ type: 'success', message: 'Role updated successfully' },
+			mockCookies
+		);
+		expect(result).toEqual({ success: true });
+	});
+
+	it('returns fail with the backend detail when the PUT fails', async () => {
+		(global.fetch as any).mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			json: async () => ({ detail: 'Update rejected' })
+		});
+
+		const result = (await server.actions.save({
+			request: makeFormData(),
+			params: { id: '2' },
+			cookies: mockCookies
+		} as any)) as any;
+
+		expect(setFlash).toHaveBeenCalledWith(
+			{ type: 'error', message: 'Update rejected' },
+			mockCookies
+		);
+		expect(result.status).toBe(500);
+	});
+
+	it('returns fail with a default message when the PUT fails without detail', async () => {
+		(global.fetch as any).mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			json: async () => ({})
+		});
+
+		const result = (await server.actions.save({
+			request: makeFormData(),
+			params: { id: '2' },
+			cookies: mockCookies
+		} as any)) as any;
+
+		expect(setFlash).toHaveBeenCalledWith(
+			{ type: 'error', message: 'Failed to update role' },
+			mockCookies
+		);
+		expect(result.status).toBe(500);
+	});
+});

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/page.svelte.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import EditRolePage from './+page.svelte';
+
+vi.mock('$app/paths', () => ({
+	resolve: vi.fn((path: string) => path)
+}));
+
+vi.mock('$app/forms', () => ({
+	enhance: vi.fn(() => ({ destroy: vi.fn() }))
+}));
+
+const mockPermissionCatalog = [
+	{ id: 1, name: 'create_test', description: null, is_active: true },
+	{ id: 2, name: 'read_test', description: null, is_active: true },
+	{ id: 3, name: 'update_test', description: null, is_active: true },
+	{ id: 4, name: 'read_candidate', description: null, is_active: true }
+];
+
+function makeData(overrides: Record<string, unknown> = {}) {
+	return {
+		role: {
+			id: 2,
+			organization_id: 10,
+			name: 'test_admin',
+			label: 'Test Admin',
+			description: 'Test Admin role',
+			is_active: true,
+			permissions: [2]
+		},
+		permissionCatalog: mockPermissionCatalog,
+		...overrides
+	};
+}
+
+function getHiddenPermissionValues(container: HTMLElement) {
+	return Array.from(container.querySelectorAll('input[name="permissions"]'))
+		.map((el) => (el as HTMLInputElement).value)
+		.sort();
+}
+
+describe('Edit Role Page (+page.svelte)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('Page structure', () => {
+		it('renders "Edit <role label>" as the heading', () => {
+			render(EditRolePage, { data: makeData() } as never);
+			expect(screen.getByRole('heading', { name: 'Edit Test Admin' })).toBeInTheDocument();
+		});
+
+		it('renders a back link pointing to the roles and permission list', () => {
+			render(EditRolePage, { data: makeData() } as never);
+			const backLink = screen.getByRole('link', { name: /back to roles and permission/i });
+			expect(backLink).toHaveAttribute('href', '/organization/roles-permissions');
+		});
+
+		it('form posts to the "save" named action', () => {
+			const { container } = render(EditRolePage, { data: makeData() } as never);
+			const form = container.querySelector('form');
+			expect(form).toHaveAttribute('method', 'POST');
+			expect(form).toHaveAttribute('action', '?/save');
+		});
+	});
+
+	describe('Hidden role fields', () => {
+		it('mirrors the role name, label, description and is_active as hidden inputs', () => {
+			const { container } = render(EditRolePage, { data: makeData() } as never);
+			expect(container.querySelector('input[name="name"]')).toHaveValue('test_admin');
+			expect(container.querySelector('input[name="label"]')).toHaveValue('Test Admin');
+			expect(container.querySelector('input[name="description"]')).toHaveValue('Test Admin role');
+			expect(container.querySelector('input[name="is_active"]')).toHaveValue('true');
+		});
+
+		it("starts with hidden permission inputs matching the role's current permissions", () => {
+			const { container } = render(EditRolePage, { data: makeData() } as never);
+			expect(getHiddenPermissionValues(container)).toEqual(['2']);
+		});
+	});
+
+	describe('Permissions matrix', () => {
+		it('groups permissions by resource and renders humanized module labels', () => {
+			render(EditRolePage, { data: makeData() } as never);
+			expect(screen.getAllByText('Test').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Candidate').length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('shows a dash for actions that have no matching permission', () => {
+			render(EditRolePage, { data: makeData() } as never);
+			expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(4);
+		});
+
+		it('checks the switch for a permission the role already has', () => {
+			render(EditRolePage, { data: makeData() } as never);
+			const switches = screen.getAllByRole('switch');
+			const checked = switches.filter((el) => el.getAttribute('data-state') === 'checked');
+			expect(checked).toHaveLength(1);
+		});
+
+		it('toggling a switch updates the hidden permission inputs', async () => {
+			const { container } = render(EditRolePage, { data: makeData() } as never);
+			const switches = screen.getAllByRole('switch');
+
+			await fireEvent.click(switches[0]);
+
+			expect(getHiddenPermissionValues(container).length).toBeGreaterThan(1);
+		});
+
+		it('toggling an already-selected permission off removes its hidden input', async () => {
+			const { container } = render(EditRolePage, { data: makeData() } as never);
+			const switches = screen.getAllByRole('switch');
+			const checkedSwitch = switches.find((el) => el.getAttribute('data-state') === 'checked')!;
+
+			await fireEvent.click(checkedSwitch);
+
+			expect(getHiddenPermissionValues(container)).toEqual([]);
+		});
+
+		it('shows the fallback message when the permission catalog is empty', () => {
+			render(EditRolePage, { data: makeData({ permissionCatalog: [] }) } as never);
+			expect(screen.getByText(/permission catalog couldn't be loaded/i)).toBeInTheDocument();
+			expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Footer actions', () => {
+		it('disables Save when nothing has been modified', () => {
+			render(EditRolePage, { data: makeData() } as never);
+			expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled();
+		});
+
+		it('enables Save once a permission is toggled', async () => {
+			render(EditRolePage, { data: makeData() } as never);
+			const switches = screen.getAllByRole('switch');
+
+			await fireEvent.click(switches[0]);
+
+			expect(screen.getByRole('button', { name: /^save$/i })).toBeEnabled();
+		});
+
+		it('renders a Cancel link back to the roles and permission list', () => {
+			render(EditRolePage, { data: makeData() } as never);
+			const cancelLink = screen.getByRole('button', { name: /cancel/i }).closest('a');
+			expect(cancelLink).toHaveAttribute('href', '/organization/roles-permissions');
+		});
+	});
+});

--- a/src/routes/(admin)/organization/roles-permissions/[action]/[id]/page.svelte.test.ts
+++ b/src/routes/(admin)/organization/roles-permissions/[action]/[id]/page.svelte.test.ts
@@ -15,7 +15,7 @@ const mockPermissionCatalog = [
 	{ id: 1, name: 'create_test', description: null, is_active: true },
 	{ id: 2, name: 'read_test', description: null, is_active: true },
 	{ id: 3, name: 'update_test', description: null, is_active: true },
-	{ id: 4, name: 'read_candidate', description: null, is_active: true }
+	{ id: 4, name: 'read_tag', description: null, is_active: true }
 ];
 
 function makeData(overrides: Record<string, unknown> = {}) {
@@ -84,7 +84,7 @@ describe('Edit Role Page (+page.svelte)', () => {
 		it('groups permissions by resource and renders humanized module labels', () => {
 			render(EditRolePage, { data: makeData() } as never);
 			expect(screen.getAllByText('Test').length).toBeGreaterThanOrEqual(1);
-			expect(screen.getAllByText('Candidate').length).toBeGreaterThanOrEqual(1);
+			expect(screen.getAllByText('Tag').length).toBeGreaterThanOrEqual(1);
 		});
 
 		it('shows a dash for actions that have no matching permission', () => {

--- a/src/routes/(admin)/organization/roles-permissions/columns.ts
+++ b/src/routes/(admin)/organization/roles-permissions/columns.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import type { ColumnDef } from '@tanstack/table-core';
 import TruncatedTextCell from '$lib/components/data-table/TruncatedTextCell.svelte';
 import { renderComponent } from '$lib/components/ui/data-table/index.js';
+import { DataTableActions } from '$lib/components/data-table/index.js';
+import { resolve } from '$app/paths';
 
 export const roleSchema = z.object({
 	id: z.number(),
@@ -10,11 +12,26 @@ export const roleSchema = z.object({
 
 export type Role = z.infer<typeof roleSchema>;
 
-export const createColumns = (): ColumnDef<Role>[] => [
+export const createColumns = (permissions?: { canEdit?: boolean }): ColumnDef<Role>[] => [
 	{
 		accessorKey: 'label',
 		header: 'Role',
 		cell: ({ row }) => renderComponent(TruncatedTextCell, { value: row.original.label }),
 		meta: { cellClassName: 'py-5' }
+	},
+	{
+		id: 'actions',
+		enableSorting: false,
+		enableHiding: false,
+		size: 60,
+		cell: ({ row }) =>
+			renderComponent(DataTableActions, {
+				entityName: 'Role',
+				editUrl: resolve(`/organization/roles-permissions/edit/${row.original.id}`),
+				deleteUrl: '',
+				canEdit: permissions?.canEdit ?? true,
+				canDelete: false,
+				editInline: true
+			})
 	}
 ];

--- a/src/routes/(admin)/organization/roles-permissions/columns.ts
+++ b/src/routes/(admin)/organization/roles-permissions/columns.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import type { ColumnDef } from '@tanstack/table-core';
+import TruncatedTextCell from '$lib/components/data-table/TruncatedTextCell.svelte';
+import { renderComponent } from '$lib/components/ui/data-table/index.js';
+
+export const roleSchema = z.object({
+	id: z.number(),
+	label: z.string()
+});
+
+export type Role = z.infer<typeof roleSchema>;
+
+export const createColumns = (): ColumnDef<Role>[] => [
+	{
+		accessorKey: 'label',
+		header: 'Role',
+		cell: ({ row }) => renderComponent(TruncatedTextCell, { value: row.original.label }),
+		meta: { cellClassName: 'py-5' }
+	}
+];

--- a/src/routes/(admin)/organization/roles-permissions/page.server.test.ts
+++ b/src/routes/(admin)/organization/roles-permissions/page.server.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { load } from './+page.server';
 
+vi.mock('$env/static/private', () => ({
+	BACKEND_URL: 'http://fake-backend.com'
+}));
+
 const requireLoginMock = vi.fn(() => ({
 	id: 1,
 	organization_id: 10,
@@ -8,7 +12,8 @@ const requireLoginMock = vi.fn(() => ({
 }));
 
 vi.mock('$lib/server/auth', () => ({
-	requireLogin: (...args: unknown[]) => requireLoginMock(...args)
+	requireLogin: (...args: unknown[]) => requireLoginMock(...args),
+	getSessionTokenCookie: vi.fn(() => 'fake-token')
 }));
 
 const requirePermissionMock = vi.fn();
@@ -19,17 +24,28 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	}
 }));
 
+const setFlashMock = vi.fn();
+vi.mock('sveltekit-flash-message/server', () => ({
+	setFlash: (...args: unknown[]) => setFlashMock(...args)
+}));
+
+global.fetch = vi.fn();
+
 describe('load', () => {
 	beforeEach(() => vi.clearAllMocks());
 
 	it('requires the user to be logged in', async () => {
-		await load({} as never);
+		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({ data: [] }) });
+
+		await load({ cookies: {} } as any);
 
 		expect(requireLoginMock).toHaveBeenCalled();
 	});
 
 	it('requires the READ_ROLE permission for the logged-in user', async () => {
-		await load({} as never);
+		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({ data: [] }) });
+
+		await load({ cookies: {} } as any);
 
 		expect(requirePermissionMock).toHaveBeenCalledWith(
 			expect.objectContaining({ organization_id: 10 }),
@@ -37,24 +53,75 @@ describe('load', () => {
 		);
 	});
 
-	it('checks permission after resolving the logged-in user', async () => {
-		const callOrder: string[] = [];
-		requireLoginMock.mockImplementationOnce(() => {
-			callOrder.push('requireLogin');
-			return { id: 1, organization_id: 10, permissions: ['read_role'] };
-		});
-		requirePermissionMock.mockImplementationOnce(() => {
-			callOrder.push('requirePermission');
-		});
+	it('fetches from the roles endpoint', async () => {
+		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({ data: [] }) });
 
-		await load({} as never);
+		await load({ cookies: {} } as any);
 
-		expect(callOrder).toEqual(['requireLogin', 'requirePermission']);
+		const fetchUrl = (global.fetch as any).mock.calls[0][0];
+		expect(fetchUrl).toBe('http://fake-backend.com/roles/');
 	});
 
-	it('resolves with an empty object when authorized', async () => {
-		const result = await load({} as never);
+	it('sends the Bearer token in the Authorization header', async () => {
+		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({ data: [] }) });
 
-		expect(result).toEqual({});
+		await load({ cookies: {} } as any);
+
+		const fetchOptions = (global.fetch as any).mock.calls[0][1];
+		expect(fetchOptions.headers.Authorization).toBe('Bearer fake-token');
+	});
+
+	it('returns roles when the API call succeeds', async () => {
+		const fakeRoles = [
+			{ id: 1, label: 'Super Admin' },
+			{ id: 2, label: 'System Admin' }
+		];
+		(global.fetch as any).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ data: fakeRoles })
+		});
+
+		const result = await load({ cookies: {} } as any);
+
+		expect(result.roles).toEqual(fakeRoles);
+	});
+
+	it('sets an error flash and returns an empty roles list when the API call fails', async () => {
+		(global.fetch as any).mockResolvedValueOnce({
+			ok: false,
+			statusText: 'Internal Server Error',
+			json: async () => ({ detail: 'Something went wrong' })
+		});
+
+		const cookies = {};
+		const result = await load({ cookies } as any);
+
+		expect(setFlashMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'error',
+				message: expect.stringContaining('Something went wrong')
+			}),
+			cookies
+		);
+		expect(result.roles).toEqual([]);
+	});
+
+	it('falls back to statusText when the API error has no detail', async () => {
+		(global.fetch as any).mockResolvedValueOnce({
+			ok: false,
+			statusText: 'Service Unavailable',
+			json: async () => ({})
+		});
+
+		const cookies = {};
+		await load({ cookies } as any);
+
+		expect(setFlashMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'error',
+				message: expect.stringContaining('Service Unavailable')
+			}),
+			cookies
+		);
 	});
 });

--- a/src/routes/(admin)/organization/roles-permissions/page.server.test.ts
+++ b/src/routes/(admin)/organization/roles-permissions/page.server.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { load } from './+page.server';
+
+const requireLoginMock = vi.fn(() => ({
+	id: 1,
+	organization_id: 10,
+	permissions: ['read_role']
+}));
+
+vi.mock('$lib/server/auth', () => ({
+	requireLogin: (...args: unknown[]) => requireLoginMock(...args)
+}));
+
+const requirePermissionMock = vi.fn();
+vi.mock('$lib/utils/permissions.js', () => ({
+	requirePermission: (...args: unknown[]) => requirePermissionMock(...args),
+	PERMISSIONS: {
+		READ_ROLE: 'read_role'
+	}
+}));
+
+describe('load', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('requires the user to be logged in', async () => {
+		await load({} as never);
+
+		expect(requireLoginMock).toHaveBeenCalled();
+	});
+
+	it('requires the READ_ROLE permission for the logged-in user', async () => {
+		await load({} as never);
+
+		expect(requirePermissionMock).toHaveBeenCalledWith(
+			expect.objectContaining({ organization_id: 10 }),
+			'read_role'
+		);
+	});
+
+	it('checks permission after resolving the logged-in user', async () => {
+		const callOrder: string[] = [];
+		requireLoginMock.mockImplementationOnce(() => {
+			callOrder.push('requireLogin');
+			return { id: 1, organization_id: 10, permissions: ['read_role'] };
+		});
+		requirePermissionMock.mockImplementationOnce(() => {
+			callOrder.push('requirePermission');
+		});
+
+		await load({} as never);
+
+		expect(callOrder).toEqual(['requireLogin', 'requirePermission']);
+	});
+
+	it('resolves with an empty object when authorized', async () => {
+		const result = await load({} as never);
+
+		expect(result).toEqual({});
+	});
+});

--- a/src/routes/(admin)/organization/roles-permissions/page.svelte.test.ts
+++ b/src/routes/(admin)/organization/roles-permissions/page.svelte.test.ts
@@ -1,24 +1,67 @@
 import { describe, it, expect } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
+import { vi } from 'vitest';
 import RolesPermissionsPage from './+page.svelte';
 
+vi.mock('$app/paths', () => ({
+	resolve: vi.fn((path: string) => path)
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(),
+	invalidateAll: vi.fn()
+}));
+
+vi.mock('$app/state', () => ({
+	page: { url: new URL('http://localhost/organization/roles-permissions') }
+}));
+
+const mockRoles = [
+	{ id: 1, label: 'Super Admin' },
+	{ id: 2, label: 'System Admin' },
+	{ id: 3, label: 'State Admin' }
+];
+
+function makeData(overrides: Record<string, unknown> = {}) {
+	return {
+		roles: mockRoles,
+		user: { id: 1, organization_id: 10, permissions: [] },
+		...overrides
+	};
+}
+
 describe('Roles and Permission Page (+page.svelte)', () => {
-	it('renders the "Roles and Permission" heading', () => {
-		render(RolesPermissionsPage);
-		expect(screen.getByRole('heading', { name: /roles and permission/i })).toBeInTheDocument();
+	describe('Page structure', () => {
+		it('renders the "Roles and Permission" heading', () => {
+			render(RolesPermissionsPage, { data: makeData() } as never);
+			expect(screen.getByRole('heading', { name: /roles and permission/i })).toBeInTheDocument();
+		});
 	});
 
-	it('shows the coming soon placeholder message', () => {
-		render(RolesPermissionsPage);
-		expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
-		expect(
-			screen.getByText(/roles and permission management is on its way/i)
-		).toBeInTheDocument();
-	});
+	describe('Data table content', () => {
+		it('renders a "Role" column header', () => {
+			render(RolesPermissionsPage, { data: makeData() } as never);
+			expect(screen.getByText('Role')).toBeInTheDocument();
+		});
 
-	it('does not render a data table or listing content', () => {
-		const { container } = render(RolesPermissionsPage);
-		expect(container.querySelector('table')).not.toBeInTheDocument();
+		it('renders each role name', () => {
+			render(RolesPermissionsPage, { data: makeData() } as never);
+			expect(screen.getByText('Super Admin')).toBeInTheDocument();
+			expect(screen.getByText('System Admin')).toBeInTheDocument();
+			expect(screen.getByText('State Admin')).toBeInTheDocument();
+		});
+
+		it('does not render any column other than "Role"', () => {
+			render(RolesPermissionsPage, { data: makeData() } as never);
+			const headers = screen.getAllByRole('columnheader');
+			expect(headers).toHaveLength(1);
+			expect(headers[0]).toHaveTextContent('Role');
+		});
+
+		it('renders without crashing when the roles list is empty', () => {
+			render(RolesPermissionsPage, { data: makeData({ roles: [] }) } as never);
+			expect(screen.getByText(/no results/i)).toBeInTheDocument();
+		});
 	});
 });

--- a/src/routes/(admin)/organization/roles-permissions/page.svelte.test.ts
+++ b/src/routes/(admin)/organization/roles-permissions/page.svelte.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
-import { vi } from 'vitest';
 import RolesPermissionsPage from './+page.svelte';
 
 vi.mock('$app/paths', () => ({
@@ -15,6 +14,10 @@ vi.mock('$app/navigation', () => ({
 
 vi.mock('$app/state', () => ({
 	page: { url: new URL('http://localhost/organization/roles-permissions') }
+}));
+
+vi.mock('$lib/utils/permissions.js', () => ({
+	canUpdate: vi.fn()
 }));
 
 const mockRoles = [
@@ -32,6 +35,12 @@ function makeData(overrides: Record<string, unknown> = {}) {
 }
 
 describe('Roles and Permission Page (+page.svelte)', () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const permissions = await import('$lib/utils/permissions.js');
+		vi.mocked(permissions.canUpdate).mockReturnValue(true);
+	});
+
 	describe('Page structure', () => {
 		it('renders the "Roles and Permission" heading', () => {
 			render(RolesPermissionsPage, { data: makeData() } as never);
@@ -52,16 +61,45 @@ describe('Roles and Permission Page (+page.svelte)', () => {
 			expect(screen.getByText('State Admin')).toBeInTheDocument();
 		});
 
-		it('does not render any column other than "Role"', () => {
+		it('does not render any column other than "Role" and the row actions', () => {
 			render(RolesPermissionsPage, { data: makeData() } as never);
 			const headers = screen.getAllByRole('columnheader');
-			expect(headers).toHaveLength(1);
+			expect(headers).toHaveLength(2);
 			expect(headers[0]).toHaveTextContent('Role');
 		});
 
 		it('renders without crashing when the roles list is empty', () => {
 			render(RolesPermissionsPage, { data: makeData({ roles: [] }) } as never);
 			expect(screen.getByText(/no results/i)).toBeInTheDocument();
+		});
+	});
+
+	describe('Row edit action', () => {
+		it('shows an Edit action for each row when the user has update permission', async () => {
+			const permissions = await import('$lib/utils/permissions.js');
+			vi.mocked(permissions.canUpdate).mockReturnValue(true);
+
+			render(RolesPermissionsPage, { data: makeData() } as never);
+			expect(screen.getAllByText('Edit')).toHaveLength(mockRoles.length);
+		});
+
+		it('links the Edit action to the [action]/[id] edit route for that role', async () => {
+			const permissions = await import('$lib/utils/permissions.js');
+			vi.mocked(permissions.canUpdate).mockReturnValue(true);
+
+			render(RolesPermissionsPage, { data: makeData() } as never);
+			const links = screen.getAllByText('Edit').map((el) => el.closest('a'));
+			expect(links[0]).toHaveAttribute('href', '/organization/roles-permissions/edit/1');
+			expect(links[1]).toHaveAttribute('href', '/organization/roles-permissions/edit/2');
+			expect(links[2]).toHaveAttribute('href', '/organization/roles-permissions/edit/3');
+		});
+
+		it('hides the Edit action for each row when the user lacks update permission', async () => {
+			const permissions = await import('$lib/utils/permissions.js');
+			vi.mocked(permissions.canUpdate).mockReturnValue(false);
+
+			render(RolesPermissionsPage, { data: makeData() } as never);
+			expect(screen.queryByText('Edit')).not.toBeInTheDocument();
 		});
 	});
 });

--- a/src/routes/(admin)/organization/roles-permissions/page.svelte.test.ts
+++ b/src/routes/(admin)/organization/roles-permissions/page.svelte.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import RolesPermissionsPage from './+page.svelte';
+
+describe('Roles and Permission Page (+page.svelte)', () => {
+	it('renders the "Roles and Permission" heading', () => {
+		render(RolesPermissionsPage);
+		expect(screen.getByRole('heading', { name: /roles and permission/i })).toBeInTheDocument();
+	});
+
+	it('shows the coming soon placeholder message', () => {
+		render(RolesPermissionsPage);
+		expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+		expect(
+			screen.getByText(/roles and permission management is on its way/i)
+		).toBeInTheDocument();
+	});
+
+	it('does not render a data table or listing content', () => {
+		const { container } = render(RolesPermissionsPage);
+		expect(container.querySelector('table')).not.toBeInTheDocument();
+	});
+});

--- a/src/routes/(admin)/tests/test-[type]/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/+page.svelte
@@ -240,7 +240,7 @@
 				</Button>
 			</a>
 		{/if}
-		{#if !data?.is_template && canReadTestTemplate}
+		{#if !data?.is_template && canReadTestTemplate && canCreate(data.user, 'test')}
 			<a href={page.url.pathname + '/convert'}
 				><Button class="font-semibold"><Plus />Create from {term('test_template')}</Button></a
 			>

--- a/src/routes/(admin)/tests/test-[type]/columns.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/columns.svelte.test.ts
@@ -56,10 +56,10 @@ function getActionProps(user: User | null, test: Test) {
 }
 
 describe('createTestColumns — edit/delete visibility based on ownership', () => {
-	const currentUser = makeUser('1');
+	const currentUser = makeUser('1', ['update_test', 'delete_test']);
 	const otherUser = makeUser('99');
-	const superAdminUser = makeUser('99', ['create_organization']);
-	const systemAdminUser = makeUser('99', ['update_my_organization']);
+	const superAdminUser = makeUser('99', ['create_organization', 'update_test', 'delete_test']);
+	const systemAdminUser = makeUser('99', ['update_my_organization', 'update_test', 'delete_test']);
 
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/src/routes/(admin)/tests/test-[type]/columns.ts
+++ b/src/routes/(admin)/tests/test-[type]/columns.ts
@@ -11,7 +11,13 @@ import { DataTableActions } from '$lib/components/data-table/index.js';
 import TagCell from '$lib/components/data-table/TagCell.svelte';
 import TruncatedTextCell from '$lib/components/data-table/TruncatedTextCell.svelte';
 import TestStatusBadge from '$lib/components/data-table/TestStatusBadge.svelte';
-import { getUserDistrict, isOwnEntity, type User } from '$lib/utils/permissions.js';
+import {
+	canDelete,
+	canUpdate,
+	getUserDistrict,
+	isOwnEntity,
+	type User
+} from '$lib/utils/permissions.js';
 import { resolve } from '$app/paths';
 import type { NomenclatureKey } from '$lib/nomenclature';
 import type { TestStatus } from '$lib/types/test.js';
@@ -169,6 +175,9 @@ export const createTestColumns = (
 			}
 
 			const isOwner = isOwnEntity(user ?? null, test.created_by_id);
+			const entityKey = isTemplate ? 'test-template' : 'test';
+			const canEditTest = canUpdate(user ?? null, entityKey) && isOwner;
+			const canDeleteTest = canDelete(user ?? null, entityKey) && isOwner;
 
 			return renderComponent(DataTableActions, {
 				id: test.id,
@@ -177,8 +186,8 @@ export const createTestColumns = (
 				deleteUrl: resolve(`${baseUrl}/${test.id}?/delete`),
 				customActions,
 				onDelete: () => onDelete(test.id),
-				canEdit: isOwner,
-				canDelete: isOwner,
+				canEdit: canEditTest,
+				canDelete: canDeleteTest,
 				editInline: true
 			});
 		}


### PR DESCRIPTION
fixes: #585 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Roles and Permission** to the **My Organisation** submenu and introduced an admin **Roles** listing with an **Edit role permissions** screen (permission matrix with Save/Cancel).

* **Access Control**
  * Updated sidebar visibility rules so **Integrations** now shows based on read access, and **Roles and Permission** appears only when the user has the required role permission.
  * Enforced authentication/authorization on the admin **Roles** and **Organization** pages, including Save flows.
  * Save now redirects to the role edit page on success.

* **Tests**
  * Added/updated automated tests covering menu visibility, permission enforcement, loading/error handling, and UI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->