### PR TITLE
Retaining list of tags added for Random Tag count

### DIFF
--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
@@ -60,20 +60,15 @@
 				: $formData.random_tag_count.reduce((sum, t) => sum + (Number(t.count ?? 0) || 0), 0)
 	);
 
-	// Seeds random_tag_count from tag_ids: appends any Primary-tab tags not already
-	// present, preserving existing entries (and their counts) untouched. Never removes
-	// entries — tags picked directly on this page must survive even if tag_ids doesn't
-	// include them. Called on mount and when switching back to tagBased — not reactive.
+	// Seeds random_tag_count from tag_ids as a one-time default, only when nothing has
+	// been picked yet. Once the user has any tags here (added or removed directly on
+	// this page), later Primary-tab tag changes are never auto-applied — otherwise a
+	// tag intentionally removed here would keep reappearing as long as it stays in
+	// tag_ids. Called on mount and when switching back to tagBased — not reactive.
 	const syncTagsFromTagIds = () => {
-		const current = $formData.random_tag_count as Array<{
-			id: string;
-			name: string;
-			count?: number;
-		}>;
+		if ($formData.random_tag_count.length > 0) return;
 		const tagIds = $formData.tag_ids as Filter[];
-		const currentIds = new Set(current.map((t) => t.id));
-		const added = tagIds.filter((t) => !currentIds.has(t.id));
-		$formData.random_tag_count = [...current, ...added.map((t) => ({ id: t.id, name: t.name }))];
+		$formData.random_tag_count = tagIds.map((t) => ({ id: t.id, name: t.name }));
 	};
 
 	if (!isSectionedTest) {

--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte
@@ -60,9 +60,10 @@
 				: $formData.random_tag_count.reduce((sum, t) => sum + (Number(t.count ?? 0) || 0), 0)
 	);
 
-	// Syncs random_tag_count with tag_ids: drops entries whose tag was removed,
-	// appends new tags, and preserves existing counts. Called on mount and when
-	// switching back to tagBased — not reactive.
+	// Seeds random_tag_count from tag_ids: appends any Primary-tab tags not already
+	// present, preserving existing entries (and their counts) untouched. Never removes
+	// entries — tags picked directly on this page must survive even if tag_ids doesn't
+	// include them. Called on mount and when switching back to tagBased — not reactive.
 	const syncTagsFromTagIds = () => {
 		const current = $formData.random_tag_count as Array<{
 			id: string;
@@ -70,13 +71,9 @@
 			count?: number;
 		}>;
 		const tagIds = $formData.tag_ids as Filter[];
-		const tagIdMap = new Map(tagIds.map((t) => [t.id, t.name]));
-		const kept = current
-			.filter((t) => tagIdMap.has(t.id))
-			.map((t) => ({ ...t, name: tagIdMap.get(t.id) as string }));
-		const keptIds = new Set(kept.map((t) => t.id));
-		const added = tagIds.filter((t) => !keptIds.has(t.id));
-		$formData.random_tag_count = [...kept, ...added.map((t) => ({ id: t.id, name: t.name }))];
+		const currentIds = new Set(current.map((t) => t.id));
+		const added = tagIds.filter((t) => !currentIds.has(t.id));
+		$formData.random_tag_count = [...current, ...added.map((t) => ({ id: t.id, name: t.name }))];
 	};
 
 	if (!isSectionedTest) {

--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
@@ -328,10 +328,11 @@ describe('QuestionList', () => {
 			expect(screen.getByText('Maths')).toBeInTheDocument();
 		});
 
-		it('drops a tag from random_tag_count when it has been removed from tag_ids', async () => {
+		it('keeps a tag in random_tag_count even after it has been removed from tag_ids', async () => {
 			// Simulates editing a saved test where the user removed Maths on the Primary
-			// page before navigating to Questions. On mount, syncTagsFromTagIds should
-			// prune random_tag_count so the stale tag is not submitted to the backend.
+			// page before navigating to Questions. Maths was picked directly on the
+			// Questions page (independent of tag_ids), so it must survive the mount-time
+			// sync rather than being silently dropped along with its count.
 			const formData = makeFormData({
 				tag_ids: [{ id: '1', name: 'Science' }],
 				random_tag_count: [
@@ -344,11 +345,14 @@ describe('QuestionList', () => {
 			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
 
 			await waitFor(() => {
-				expect(screen.queryByText('Maths')).not.toBeInTheDocument();
+				expect(screen.getByText('Science')).toBeInTheDocument();
 			});
 
-			expect(screen.getByText('Science')).toBeInTheDocument();
-			expect(get(formData).random_tag_count).toEqual([{ id: '1', name: 'Science', count: 5 }]);
+			expect(screen.getByText('Maths')).toBeInTheDocument();
+			expect(get(formData).random_tag_count).toEqual([
+				{ id: '1', name: 'Science', count: 5 },
+				{ id: '2', name: 'Maths', count: 3 }
+			]);
 		});
 
 		it('uses Manual Selection mode when explicit question IDs exist, even if tags are set', () => {

--- a/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/QuestionList.svelte.test.ts
@@ -300,10 +300,11 @@ describe('QuestionList', () => {
 			).toBeInTheDocument();
 		});
 
-		it('shows a tag added to tag_ids after save when random_tag_count already has entries', async () => {
+		it('does not auto-add a new tag_ids tag once random_tag_count already has entries', async () => {
 			// Simulates editing a saved test where the user added a third tag on the Primary
-			// page before navigating to Questions. On mount, syncTagsFromTagIds runs once and
-			// adds History (present in tag_ids but absent from random_tag_count) to the table.
+			// page before navigating to Questions. random_tag_count already has entries (the
+			// user has taken ownership of this list), so History is not auto-applied — otherwise
+			// a tag intentionally removed here would keep reappearing as long as it stays in tag_ids.
 			const formData = makeFormData({
 				tag_ids: [
 					{ id: '1', name: 'Science' },
@@ -319,13 +320,13 @@ describe('QuestionList', () => {
 
 			render(QuestionList, { formData, questions: [], questionParams: {}, user: null });
 
-			await waitFor(() => {
-				expect(screen.getByText('History')).toBeInTheDocument();
-			});
-
-			// Existing tags and their counts remain untouched
 			expect(screen.getByText('Science')).toBeInTheDocument();
 			expect(screen.getByText('Maths')).toBeInTheDocument();
+			expect(screen.queryByText('History')).not.toBeInTheDocument();
+			expect(get(formData).random_tag_count).toEqual([
+				{ id: '1', name: 'Science', count: 5 },
+				{ id: '2', name: 'Maths', count: 3 }
+			]);
 		});
 
 		it('keeps a tag in random_tag_count even after it has been removed from tag_ids', async () => {


### PR DESCRIPTION
Fixes #584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic re-sync of random tag counts once they’re already set, avoiding unintended tag additions/removals during edits.
  * Ensured saved test tag selections no longer cause Questions UI and random tag counts to be unexpectedly altered on subsequent changes.

* **Tests**
  * Updated and renamed scenarios to verify that existing random tag count entries remain unchanged when editing saved tests, including when tags are removed from the current selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->