### PR TITLE
Replace provider permissions with update_my_organization

### DIFF
--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -74,7 +74,7 @@
 		if (
 			hasAnyPermission(data.user, [
 				PERMISSIONS.UPDATE_ORGANIZATION_SETTINGS,
-				PERMISSIONS.UPDATE_MY_ORGANIZATION_SETTINGS
+				PERMISSIONS.UPDATE_MY_ORGANIZATION
 			])
 		) {
 			children.push({ title: 'Organisation Settings', url: '/organization/settings' });

--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -11,7 +11,6 @@
 	import {
 		canCreate,
 		canUpdate,
-		hasAnyPermission,
 		hasPermission,
 		isSuperAdmin,
 		PERMISSIONS
@@ -71,12 +70,7 @@
 		if (hasPermission(data.user, PERMISSIONS.UPDATE_MY_ORGANIZATION)) {
 			children.push({ title: 'Organisation Details', url: '/organization' });
 		}
-		if (
-			hasAnyPermission(data.user, [
-				PERMISSIONS.UPDATE_ORGANIZATION_SETTINGS,
-				PERMISSIONS.UPDATE_MY_ORGANIZATION
-			])
-		) {
+		if (hasPermission(data.user, PERMISSIONS.UPDATE_MY_ORGANIZATION)) {
 			children.push({ title: 'Organisation Settings', url: '/organization/settings' });
 		}
 		if (hasPermission(data.user, PERMISSIONS.UPDATE_MY_ORGANIZATION)) {

--- a/src/lib/components/app-sidebar.svelte.test.ts
+++ b/src/lib/components/app-sidebar.svelte.test.ts
@@ -14,7 +14,6 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	canCreate: vi.fn(() => false),
 	canUpdate: vi.fn(() => false),
 	hasPermission: vi.fn(() => false),
-	hasAnyPermission: vi.fn(() => false),
 	isSuperAdmin: vi.fn(() => false),
 	PERMISSIONS: {}
 }));

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -124,7 +124,6 @@ export const PERMISSIONS = {
 	DELETE_ORGANIZATION: 'delete_organization',
 	READ_ORGANIZATION: 'read_organization',
 	UPDATE_MY_ORGANIZATION: 'update_my_organization',
-	UPDATE_ORGANIZATION_SETTINGS: 'update_organization_settings',
 
 	// Certificate permissions
 	CREATE_CERTIFICATE: 'create_certificate',

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -99,7 +99,6 @@ export const PERMISSIONS = {
 	UPDATE_USER: 'update_user',
 	DELETE_USER: 'delete_user',
 	READ_USER: 'read_user',
-	UPDATE_USER_ME: 'update_user_me',
 
 	// Question permissions
 	CREATE_QUESTION: 'create_question',
@@ -126,7 +125,6 @@ export const PERMISSIONS = {
 	READ_ORGANIZATION: 'read_organization',
 	UPDATE_MY_ORGANIZATION: 'update_my_organization',
 	UPDATE_ORGANIZATION_SETTINGS: 'update_organization_settings',
-	UPDATE_MY_ORGANIZATION_SETTINGS: 'update_my_organization_settings',
 
 	// Certificate permissions
 	CREATE_CERTIFICATE: 'create_certificate',

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -152,13 +152,13 @@ export const PERMISSIONS = {
 
 	// Candidate permissions
 	DELETE_CANDIDATE: 'delete_candidate',
+	READ_CANDIDATE: 'read_candidate',
 
 	// Form permissions
 	CREATE_FORM: 'create_form',
 	UPDATE_FORM: 'update_form',
 	DELETE_FORM: 'delete_form',
-	READ_FORM: 'read_form',
-	READ_FORM_RESPONSE: 'read_form_response'
+	READ_FORM: 'read_form'
 } as const;
 
 /**

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -160,13 +160,7 @@ export const PERMISSIONS = {
 	UPDATE_FORM: 'update_form',
 	DELETE_FORM: 'delete_form',
 	READ_FORM: 'read_form',
-	READ_FORM_RESPONSE: 'read_form_response',
-
-	// Provider permissions
-	CREATE_PROVIDER: 'create_provider',
-	UPDATE_PROVIDER: 'update_provider',
-	DELETE_PROVIDER: 'delete_provider',
-	READ_PROVIDER: 'read_provider'
+	READ_FORM_RESPONSE: 'read_form_response'
 } as const;
 
 /**
@@ -280,10 +274,10 @@ export const ENTITY_PERMISSIONS = {
 		delete: PERMISSIONS.DELETE_FORM
 	},
 	provider: {
-		create: PERMISSIONS.CREATE_PROVIDER,
-		read: PERMISSIONS.READ_PROVIDER,
-		update: PERMISSIONS.UPDATE_PROVIDER,
-		delete: PERMISSIONS.DELETE_PROVIDER
+		create: PERMISSIONS.UPDATE_MY_ORGANIZATION,
+		read: PERMISSIONS.UPDATE_MY_ORGANIZATION,
+		update: PERMISSIONS.UPDATE_MY_ORGANIZATION,
+		delete: PERMISSIONS.UPDATE_MY_ORGANIZATION
 	}
 } as const;
 

--- a/src/routes/(admin)/organization/integrations/+page.server.ts
+++ b/src/routes/(admin)/organization/integrations/+page.server.ts
@@ -6,7 +6,7 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ cookies }) => {
 	const user = requireLogin();
-	requirePermission(user, PERMISSIONS.READ_PROVIDER);
+	requirePermission(user, PERMISSIONS.UPDATE_MY_ORGANIZATION);
 	const token = getSessionTokenCookie();
 	const orgId = user.organization_id;
 

--- a/src/routes/(admin)/organization/integrations/[action]/[id]/+page.server.ts
+++ b/src/routes/(admin)/organization/integrations/[action]/[id]/+page.server.ts
@@ -12,10 +12,8 @@ export const load: PageServerLoad = async ({ params }) => {
 	const user = requireLogin();
 	const token = getSessionTokenCookie();
 
-	if (params.action === 'add') {
-		requirePermission(user, PERMISSIONS.CREATE_PROVIDER);
-	} else if (params.action === 'edit') {
-		requirePermission(user, PERMISSIONS.UPDATE_PROVIDER);
+	if (params.action === 'add' || params.action === 'edit') {
+		requirePermission(user, PERMISSIONS.UPDATE_MY_ORGANIZATION);
 	}
 
 	const catalogRes = await fetch(`${BACKEND_URL}/providers/?page=1&size=100`, {
@@ -77,10 +75,8 @@ export const actions: Actions = {
 		const user = requireLogin();
 		const token = getSessionTokenCookie();
 
-		if (params.action === 'edit') {
-			requirePermission(user, PERMISSIONS.UPDATE_PROVIDER);
-		} else if (params.action === 'add') {
-			requirePermission(user, PERMISSIONS.CREATE_PROVIDER);
+		if (params.action === 'edit' || params.action === 'add') {
+			requirePermission(user, PERMISSIONS.UPDATE_MY_ORGANIZATION);
 		}
 
 		const form = await superValidate(request, zod4(addProviderSchema));
@@ -164,7 +160,7 @@ export const actions: Actions = {
 
 	delete: async ({ params, cookies }) => {
 		const user = requireLogin();
-		requirePermission(user, PERMISSIONS.DELETE_PROVIDER);
+		requirePermission(user, PERMISSIONS.UPDATE_MY_ORGANIZATION);
 		const token = getSessionTokenCookie();
 
 		const res = await fetch(

--- a/src/routes/(admin)/organization/integrations/[action]/[id]/page.server.test.ts
+++ b/src/routes/(admin)/organization/integrations/[action]/[id]/page.server.test.ts
@@ -17,9 +17,7 @@ vi.mock('$lib/server/auth', () => ({
 vi.mock('$lib/utils/permissions.js', () => ({
 	requirePermission: vi.fn(),
 	PERMISSIONS: {
-		CREATE_PROVIDER: 'CREATE_PROVIDER',
-		UPDATE_PROVIDER: 'UPDATE_PROVIDER',
-		DELETE_PROVIDER: 'DELETE_PROVIDER'
+		UPDATE_MY_ORGANIZATION: 'UPDATE_MY_ORGANIZATION'
 	}
 }));
 
@@ -65,7 +63,7 @@ describe('page.server load function', () => {
 		expect(result.form).toBeDefined();
 	});
 
-	it('requires the CREATE_PROVIDER permission', async () => {
+	it('requires the UPDATE_MY_ORGANIZATION permission', async () => {
 		const permissions = await import('$lib/utils/permissions.js');
 		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({ items: [] }) });
 
@@ -73,7 +71,7 @@ describe('page.server load function', () => {
 
 		expect(permissions.requirePermission).toHaveBeenCalledWith(
 			expect.objectContaining({ organization_id: 10 }),
-			'CREATE_PROVIDER'
+			'UPDATE_MY_ORGANIZATION'
 		);
 	});
 
@@ -154,7 +152,7 @@ describe('page.server load function', () => {
 			);
 		});
 
-		it('requires the UPDATE_PROVIDER permission', async () => {
+		it('requires the UPDATE_MY_ORGANIZATION permission', async () => {
 			const permissions = await import('$lib/utils/permissions.js');
 			mockOrgAndCatalogFetch();
 
@@ -162,7 +160,7 @@ describe('page.server load function', () => {
 
 			expect(permissions.requirePermission).toHaveBeenCalledWith(
 				expect.objectContaining({ organization_id: 10 }),
-				'UPDATE_PROVIDER'
+				'UPDATE_MY_ORGANIZATION'
 			);
 		});
 
@@ -235,7 +233,7 @@ describe('page.server save action', () => {
 		expect(result.status).toBe(400);
 	});
 
-	it('requires the CREATE_PROVIDER permission', async () => {
+	it('requires the UPDATE_MY_ORGANIZATION permission', async () => {
 		const permissions = await import('$lib/utils/permissions.js');
 		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
@@ -251,7 +249,7 @@ describe('page.server save action', () => {
 
 		expect(permissions.requirePermission).toHaveBeenCalledWith(
 			expect.objectContaining({ organization_id: 10 }),
-			'CREATE_PROVIDER'
+			'UPDATE_MY_ORGANIZATION'
 		);
 	});
 
@@ -360,7 +358,7 @@ describe('page.server save action', () => {
 	});
 
 	describe('edit action', () => {
-		it('requires the UPDATE_PROVIDER permission', async () => {
+		it('requires the UPDATE_MY_ORGANIZATION permission', async () => {
 			const permissions = await import('$lib/utils/permissions.js');
 			(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
@@ -376,7 +374,7 @@ describe('page.server save action', () => {
 
 			expect(permissions.requirePermission).toHaveBeenCalledWith(
 				expect.objectContaining({ organization_id: 10 }),
-				'UPDATE_PROVIDER'
+				'UPDATE_MY_ORGANIZATION'
 			);
 		});
 
@@ -451,7 +449,7 @@ describe('page.server save action', () => {
 describe('page.server delete action', () => {
 	beforeEach(() => vi.resetAllMocks());
 
-	it('requires the DELETE_PROVIDER permission', async () => {
+	it('requires the UPDATE_MY_ORGANIZATION permission', async () => {
 		const permissions = await import('$lib/utils/permissions.js');
 		(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
@@ -463,7 +461,7 @@ describe('page.server delete action', () => {
 
 		expect(permissions.requirePermission).toHaveBeenCalledWith(
 			expect.objectContaining({ organization_id: 10 }),
-			'DELETE_PROVIDER'
+			'UPDATE_MY_ORGANIZATION'
 		);
 	});
 

--- a/src/routes/(admin)/organization/integrations/page.server.test.ts
+++ b/src/routes/(admin)/organization/integrations/page.server.test.ts
@@ -8,7 +8,7 @@ vi.mock('$env/static/private', () => ({
 const requireLoginMock = vi.fn(() => ({
 	id: 1,
 	organization_id: 10,
-	permissions: ['read_provider']
+	permissions: ['update_my_organization']
 }));
 
 vi.mock('$lib/server/auth', () => ({
@@ -20,7 +20,7 @@ const requirePermissionMock = vi.fn();
 vi.mock('$lib/utils/permissions.js', () => ({
 	requirePermission: (...args: unknown[]) => requirePermissionMock(...args),
 	PERMISSIONS: {
-		READ_PROVIDER: 'read_provider'
+		UPDATE_MY_ORGANIZATION: 'update_my_organization'
 	}
 }));
 
@@ -48,7 +48,7 @@ describe('load', () => {
 		expect(result.providers).toEqual(fakeProviders);
 	});
 
-	it('requires the READ_PROVIDER permission', async () => {
+	it('requires the UPDATE_MY_ORGANIZATION permission', async () => {
 		(global.fetch as any).mockResolvedValueOnce({
 			ok: true,
 			json: async () => []
@@ -58,7 +58,7 @@ describe('load', () => {
 
 		expect(requirePermissionMock).toHaveBeenCalledWith(
 			expect.objectContaining({ organization_id: 10 }),
-			'read_provider'
+			'update_my_organization'
 		);
 	});
 

--- a/src/routes/(admin)/organization/settings/+page.server.ts
+++ b/src/routes/(admin)/organization/settings/+page.server.ts
@@ -61,7 +61,7 @@ function normalizeSettingsForBackend(input: OrganizationSettings): OrganizationS
 export const load: PageServerLoad = async ({ fetch, locals }) => {
 	requireAnyPermission(locals.user, [
 		PERMISSIONS.UPDATE_ORGANIZATION_SETTINGS,
-		PERMISSIONS.UPDATE_MY_ORGANIZATION_SETTINGS
+		PERMISSIONS.UPDATE_MY_ORGANIZATION
 	]);
 
 	const token = getSessionTokenCookie();
@@ -92,7 +92,7 @@ export const actions: Actions = {
 	save: async ({ request, fetch, cookies, locals }) => {
 		requireAnyPermission(locals.user, [
 			PERMISSIONS.UPDATE_ORGANIZATION_SETTINGS,
-			PERMISSIONS.UPDATE_MY_ORGANIZATION_SETTINGS
+			PERMISSIONS.UPDATE_MY_ORGANIZATION
 		]);
 
 		const token = getSessionTokenCookie();

--- a/src/routes/(admin)/organization/settings/+page.server.ts
+++ b/src/routes/(admin)/organization/settings/+page.server.ts
@@ -1,6 +1,6 @@
 import { BACKEND_URL } from '$env/static/private';
 import { getSessionTokenCookie } from '$lib/server/auth.js';
-import { PERMISSIONS, requireAnyPermission } from '$lib/utils/permissions.js';
+import { PERMISSIONS, requirePermission } from '$lib/utils/permissions.js';
 import { error, fail } from '@sveltejs/kit';
 import { redirect } from 'sveltekit-flash-message/server';
 import { superValidate } from 'sveltekit-superforms';
@@ -59,10 +59,7 @@ function normalizeSettingsForBackend(input: OrganizationSettings): OrganizationS
 }
 
 export const load: PageServerLoad = async ({ fetch, locals }) => {
-	requireAnyPermission(locals.user, [
-		PERMISSIONS.UPDATE_ORGANIZATION_SETTINGS,
-		PERMISSIONS.UPDATE_MY_ORGANIZATION
-	]);
+	requirePermission(locals.user, PERMISSIONS.UPDATE_MY_ORGANIZATION);
 
 	const token = getSessionTokenCookie();
 	const orgId = locals.user.organization_id;
@@ -90,10 +87,7 @@ export const load: PageServerLoad = async ({ fetch, locals }) => {
 
 export const actions: Actions = {
 	save: async ({ request, fetch, cookies, locals }) => {
-		requireAnyPermission(locals.user, [
-			PERMISSIONS.UPDATE_ORGANIZATION_SETTINGS,
-			PERMISSIONS.UPDATE_MY_ORGANIZATION
-		]);
+		requirePermission(locals.user, PERMISSIONS.UPDATE_MY_ORGANIZATION);
 
 		const token = getSessionTokenCookie();
 		const orgId = locals.user.organization_id;

--- a/src/routes/(admin)/organization/settings/page.server.test.ts
+++ b/src/routes/(admin)/organization/settings/page.server.test.ts
@@ -26,11 +26,10 @@ vi.mock('$lib/server/auth.js', () => ({
 	getSessionTokenCookie: vi.fn(() => 'fake-token')
 }));
 
-const requireAnyPermissionMock = vi.fn();
+const requirePermissionMock = vi.fn();
 vi.mock('$lib/utils/permissions.js', () => ({
-	requireAnyPermission: (...args: any[]) => requireAnyPermissionMock(...args),
+	requirePermission: (...args: any[]) => requirePermissionMock(...args),
 	PERMISSIONS: {
-		UPDATE_ORGANIZATION_SETTINGS: 'update_organization_settings',
 		UPDATE_MY_ORGANIZATION: 'update_my_organization'
 	}
 }));
@@ -122,7 +121,7 @@ describe('Organization Settings - load()', () => {
 		expect(result.form.data.test_timings.value.end_time).toBe('18:45');
 	});
 
-	it('calls requireAnyPermission with both settings permissions', async () => {
+	it('calls requirePermission with the update_my_organization permission', async () => {
 		const fetchMock = vi.fn().mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ settings: defaultSettings() })
@@ -130,14 +129,14 @@ describe('Organization Settings - load()', () => {
 
 		await load(mockEvent({ fetch: fetchMock }));
 
-		expect(requireAnyPermissionMock).toHaveBeenCalledWith(
+		expect(requirePermissionMock).toHaveBeenCalledWith(
 			expect.objectContaining({ organization_id: 42 }),
-			['update_organization_settings', 'update_my_organization']
+			'update_my_organization'
 		);
 	});
 
-	it('throws 403 when requireAnyPermission rejects', async () => {
-		requireAnyPermissionMock.mockImplementationOnce(() => {
+	it('throws 403 when requirePermission rejects', async () => {
+		requirePermissionMock.mockImplementationOnce(() => {
 			throw { status: 403, body: 'Access denied' };
 		});
 
@@ -265,8 +264,8 @@ describe('Organization Settings - actions.save', () => {
 		expect(result?.status).toBe(422);
 	});
 
-	it('enforces permissions via requireAnyPermission', async () => {
-		requireAnyPermissionMock.mockImplementationOnce(() => {
+	it('enforces permissions via requirePermission', async () => {
+		requirePermissionMock.mockImplementationOnce(() => {
 			throw { status: 403 };
 		});
 

--- a/src/routes/(admin)/organization/settings/page.server.test.ts
+++ b/src/routes/(admin)/organization/settings/page.server.test.ts
@@ -31,7 +31,7 @@ vi.mock('$lib/utils/permissions.js', () => ({
 	requireAnyPermission: (...args: any[]) => requireAnyPermissionMock(...args),
 	PERMISSIONS: {
 		UPDATE_ORGANIZATION_SETTINGS: 'update_organization_settings',
-		UPDATE_MY_ORGANIZATION_SETTINGS: 'update_my_organization_settings'
+		UPDATE_MY_ORGANIZATION: 'update_my_organization'
 	}
 }));
 
@@ -132,7 +132,7 @@ describe('Organization Settings - load()', () => {
 
 		expect(requireAnyPermissionMock).toHaveBeenCalledWith(
 			expect.objectContaining({ organization_id: 42 }),
-			['update_organization_settings', 'update_my_organization_settings']
+			['update_organization_settings', 'update_my_organization']
 		);
 	});
 


### PR DESCRIPTION
fixes : #590 
Consolidate create_provider/update_provider/delete_provider/read_provider into the existing update_my_organization permission, since provider management is an organization-scoped setting. Also fixes a mismatch where the sidebar Integrations link already checked update_my_organization while the page itself required read_provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Permissions**
  * Organization integration management now consistently uses the organization update permission for viewing, creating, editing, and deleting integrations.
  * Removed separate provider-specific permission requirements.
  * Organization settings access and navigation now use the same organization update permission.

* **Tests**
  * Updated integration and organization settings coverage to reflect the unified permission model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->