### PR TITLE
Display Loading State while Downloading Certificate

### DIFF
--- a/src/lib/components/data-table/DataTableActions.svelte
+++ b/src/lib/components/data-table/DataTableActions.svelte
@@ -12,6 +12,7 @@
 	import ListChecks from '@lucide/svelte/icons/list-checks';
 	import DownloadIcon from '@lucide/svelte/icons/download';
 	import ClipboardList from '@lucide/svelte/icons/clipboard-list';
+	import Loader2 from '@lucide/svelte/icons/loader-2';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 
 	interface CustomAction {
@@ -22,6 +23,7 @@
 		method?: string;
 		inline?: boolean;
 		iconOnly?: boolean;
+		loading?: boolean;
 	}
 
 	let {
@@ -137,9 +139,12 @@
 									variant="ghost"
 									size="icon"
 									aria-label={action.label}
+									disabled={action.loading}
 									onclick={action.action}
 								>
-									{#if IconComponent}
+									{#if action.loading}
+										<Loader2 class="h-4 w-4 animate-spin" />
+									{:else if IconComponent}
 										<IconComponent class="h-4 w-4" />
 									{/if}
 								</Button>

--- a/src/lib/components/data-table/DataTableActions.svelte.test.ts
+++ b/src/lib/components/data-table/DataTableActions.svelte.test.ts
@@ -480,6 +480,57 @@ describe('DataTableActions', () => {
 
 			expect(customAction).toHaveBeenCalledTimes(1);
 		});
+
+		it('should disable inline icon-only custom action and show a spinner when loading', async () => {
+			const customAction = vi.fn();
+			render(DataTableActions, {
+				props: {
+					...defaultProps,
+					canEdit: false,
+					canDelete: false,
+					customActions: [
+						{
+							label: 'Download Certificate',
+							action: customAction,
+							icon: 'download',
+							inline: true,
+							iconOnly: true,
+							loading: true
+						}
+					]
+				}
+			});
+
+			const actionButton = screen.getByRole('button', { name: 'Download Certificate' });
+			expect(actionButton).toBeDisabled();
+		});
+
+		it('should enable inline icon-only custom action and call it when not loading', async () => {
+			const customAction = vi.fn();
+			render(DataTableActions, {
+				props: {
+					...defaultProps,
+					canEdit: false,
+					canDelete: false,
+					customActions: [
+						{
+							label: 'Download Certificate',
+							action: customAction,
+							icon: 'download',
+							inline: true,
+							iconOnly: true,
+							loading: false
+						}
+					]
+				}
+			});
+
+			const actionButton = screen.getByRole('button', { name: 'Download Certificate' });
+			expect(actionButton).not.toBeDisabled();
+
+			await fireEvent.click(actionButton);
+			expect(customAction).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('View Report action', () => {

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
@@ -53,14 +53,14 @@
 		showResponsesOpen = true;
 	}
 
-	let downloadingCandidateId: number | null = $state(null);
+	let downloadingCandidateIds = $state(new Set<number>());
 
 	async function handleDownloadCertificate(
 		candidateId: number,
 		certificateDownloadUrl: string,
 		candidateUuid: string
 	) {
-		downloadingCandidateId = candidateId;
+		downloadingCandidateIds = new Set([...downloadingCandidateIds, candidateId]);
 		try {
 			const response = await fetch('/api/download-certificate', {
 				method: 'POST',
@@ -83,7 +83,7 @@
 			console.error('Failed to download certificate:', error);
 			toast.error('Failed to download certificate');
 		} finally {
-			downloadingCandidateId = null;
+			downloadingCandidateIds = new Set([...downloadingCandidateIds].filter((id) => id !== candidateId));
 		}
 	}
 
@@ -108,7 +108,7 @@
 			userCanDelete,
 			userCanDelete,
 			handleShowResponses,
-			downloadingCandidateId,
+			downloadingCandidateIds,
 			handleDownloadCertificate
 		)
 	);

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/+page.svelte
@@ -14,6 +14,7 @@
 	import { resolve } from '$app/paths';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import Download from '@lucide/svelte/icons/download';
+	import { toast } from 'svelte-sonner';
 
 	let { data } = $props();
 
@@ -52,6 +53,40 @@
 		showResponsesOpen = true;
 	}
 
+	let downloadingCandidateId: number | null = $state(null);
+
+	async function handleDownloadCertificate(
+		candidateId: number,
+		certificateDownloadUrl: string,
+		candidateUuid: string
+	) {
+		downloadingCandidateId = candidateId;
+		try {
+			const response = await fetch('/api/download-certificate', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ certificate_download_url: certificateDownloadUrl })
+			});
+
+			if (!response.ok) throw new Error('Download failed');
+
+			const blob = await response.blob();
+			const url = window.URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = `certificate-${candidateUuid}.png`;
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			window.URL.revokeObjectURL(url);
+		} catch (error) {
+			console.error('Failed to download certificate:', error);
+			toast.error('Failed to download certificate');
+		} finally {
+			downloadingCandidateId = null;
+		}
+	}
+
 	// handle sorting
 	function handleSort(columnId: string) {
 		const url = new URL(page.url);
@@ -72,7 +107,9 @@
 			handleDelete,
 			userCanDelete,
 			userCanDelete,
-			handleShowResponses
+			handleShowResponses,
+			downloadingCandidateId,
+			handleDownloadCertificate
 		)
 	);
 

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/columns.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/columns.ts
@@ -36,7 +36,7 @@ export const createResponseColumns = (
 	canDelete = true,
 	enableSelection = false,
 	onShowResponses?: (candidate: CandidateResponse) => void,
-	downloadingCandidateId: number | null = null,
+	downloadingCandidateIds: Set<number> = new Set(),
 	onDownloadCertificate?: (
 		candidateId: number,
 		certificateDownloadUrl: string,
@@ -114,7 +114,7 @@ export const createResponseColumns = (
 								icon: 'download',
 								inline: true,
 								iconOnly: true,
-								loading: downloadingCandidateId === row.original.candidate_id,
+								loading: downloadingCandidateIds.has(row.original.candidate_id),
 								action: () =>
 									onDownloadCertificate?.(
 										row.original.candidate_id,

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/columns.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/columns.ts
@@ -1,35 +1,9 @@
 import type { ColumnDef } from '@tanstack/table-core';
-import { toast } from 'svelte-sonner';
 import { renderComponent } from '$lib/components/ui/data-table/index.js';
 import DateCell from '$lib/components/data-table/DateCell.svelte';
 import CandidateStatusBadge from '$lib/components/data-table/CandidateStatusBadge.svelte';
 import { DataTableActions } from '$lib/components/data-table/index.js';
 import { createSelectionColumn, createSortableColumn } from '$lib/components/data-table/column-helpers';
-
-async function downloadCertificate(certificateDownloadUrl: string, candidateUuid: string) {
-	try {
-		const response = await fetch('/api/download-certificate', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ certificate_download_url: certificateDownloadUrl })
-		});
-
-		if (!response.ok) throw new Error('Download failed');
-
-		const blob = await response.blob();
-		const url = window.URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = `certificate-${candidateUuid}.png`;
-		document.body.appendChild(a);
-		a.click();
-		document.body.removeChild(a);
-		window.URL.revokeObjectURL(url);
-	} catch (error) {
-		console.error('Failed to download certificate:', error);
-		toast.error('Failed to download certificate');
-	}
-}
 
 type CandidateStatus = 'submitted' | 'not_submitted';
 export interface CandidateResult {
@@ -61,7 +35,13 @@ export const createResponseColumns = (
 	onDelete?: (candidateId: number) => void,
 	canDelete = true,
 	enableSelection = false,
-	onShowResponses?: (candidate: CandidateResponse) => void
+	onShowResponses?: (candidate: CandidateResponse) => void,
+	downloadingCandidateId: number | null = null,
+	onDownloadCertificate?: (
+		candidateId: number,
+		certificateDownloadUrl: string,
+		candidateUuid: string
+	) => void
 ): ColumnDef<CandidateResponse>[] => [
 	...(enableSelection ? [createSelectionColumn<CandidateResponse>()] : []),
 	{
@@ -134,7 +114,13 @@ export const createResponseColumns = (
 								icon: 'download',
 								inline: true,
 								iconOnly: true,
-								action: () => downloadCertificate(certificateUrl, row.original.candidate_uuid)
+								loading: downloadingCandidateId === row.original.candidate_id,
+								action: () =>
+									onDownloadCertificate?.(
+										row.original.candidate_id,
+										certificateUrl,
+										row.original.candidate_uuid
+									)
 							});
 						}
 

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
@@ -381,6 +381,50 @@ describe('Candidate Responses page (UI)', () => {
 			});
 			expect(window.URL.createObjectURL).not.toHaveBeenCalled();
 		});
+
+		it('disables the button and shows a loading spinner while the certificate is generating, then re-enables it on success', async () => {
+			const blob = new Blob(['pdf-bytes'], { type: 'image/png' });
+			let resolveFetch: (value: { ok: boolean; blob: () => Promise<Blob> }) => void;
+			const fetchMock = vi.fn(
+				() =>
+					new Promise((resolve) => {
+						resolveFetch = resolve;
+					})
+			);
+			vi.stubGlobal('fetch', fetchMock);
+
+			render(ResponsesPage, {
+				data: makeData([candidateWithCertificate], { canDelete: true })
+			} as any);
+
+			const downloadButton = screen.getByRole('button', { name: 'Download Certificate' });
+			expect(downloadButton).not.toBeDisabled();
+
+			await fireEvent.click(downloadButton);
+			expect(downloadButton).toBeDisabled();
+
+			resolveFetch!({ ok: true, blob: () => Promise.resolve(blob) });
+
+			await waitFor(() => {
+				expect(downloadButton).not.toBeDisabled();
+			});
+		});
+
+		it('re-enables the button after a failed download', async () => {
+			const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+			vi.stubGlobal('fetch', fetchMock);
+
+			render(ResponsesPage, {
+				data: makeData([candidateWithCertificate], { canDelete: true })
+			} as any);
+
+			const downloadButton = screen.getByRole('button', { name: 'Download Certificate' });
+			await fireEvent.click(downloadButton);
+
+			await waitFor(() => {
+				expect(downloadButton).not.toBeDisabled();
+			});
+		});
 	});
 
 	// ─────────────────────────────────────────────────────────────────────────

--- a/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
+++ b/src/routes/(admin)/tests/test-[type]/[id]/responses/page.svelte.test.ts
@@ -425,6 +425,64 @@ describe('Candidate Responses page (UI)', () => {
 				expect(downloadButton).not.toBeDisabled();
 			});
 		});
+
+		it('keeps each row disabled independently when two downloads resolve in reverse order', async () => {
+			const secondCandidate: CandidateResponse = {
+				candidate_id: 99,
+				candidate_uuid: 'candidate-zzz',
+				status: 'submitted',
+				start_time: '2026-06-01T11:00:00Z',
+				end_time: '2026-06-01T11:30:00Z',
+				time_taken_seconds: 120,
+				result: {
+					correct_answer: 8,
+					incorrect_answer: 2,
+					mandatory_not_attempted: 0,
+					optional_not_attempted: 0,
+					total_questions: 10,
+					marks_obtained: 8,
+					marks_maximum: 10,
+					certificate_download_url: 'https://example.com/certificates/candidate-zzz.pdf'
+				}
+			};
+
+			const blob = new Blob(['pdf-bytes'], { type: 'image/png' });
+			let resolveFirst: (value: { ok: boolean; blob: () => Promise<Blob> }) => void;
+			let resolveSecond: (value: { ok: boolean; blob: () => Promise<Blob> }) => void;
+
+			const fetchMock = vi
+				.fn()
+				.mockImplementationOnce(
+					() => new Promise((resolve) => { resolveFirst = resolve; })
+				)
+				.mockImplementationOnce(
+					() => new Promise((resolve) => { resolveSecond = resolve; })
+				);
+			vi.stubGlobal('fetch', fetchMock);
+
+			render(ResponsesPage, {
+				data: makeData([candidateWithCertificate, secondCandidate], { canDelete: true })
+			} as any);
+
+			const [firstButton, secondButton] = screen.getAllByRole('button', {
+				name: 'Download Certificate'
+			});
+
+			await fireEvent.click(firstButton);
+			await fireEvent.click(secondButton);
+
+			expect(firstButton).toBeDisabled();
+			expect(secondButton).toBeDisabled();
+
+			// second resolves first
+			resolveSecond!({ ok: true, blob: () => Promise.resolve(blob) });
+			await waitFor(() => expect(secondButton).not.toBeDisabled());
+			expect(firstButton).toBeDisabled();
+
+			// first resolves after
+			resolveFirst!({ ok: true, blob: () => Promise.resolve(blob) });
+			await waitFor(() => expect(firstButton).not.toBeDisabled());
+		});
 	});
 
 	// ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #592 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added certificate downloads for candidate responses as candidate-specific PNG files.
  * Added per-candidate loading indicators and disabled states during certificate downloads.
  * Added loading indicators and disabled states for icon-only custom actions.

* **Bug Fixes**
  * Download actions now recover after successful or failed requests, allowing users to retry.
  * Independent downloads maintain accurate loading states when multiple requests run simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->