### PR TITLE
Configure Tags as Public To show for Candidate  Answer Review

### DIFF
--- a/src/routes/(admin)/tags/+page.server.ts
+++ b/src/routes/(admin)/tags/+page.server.ts
@@ -71,6 +71,7 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const name = formData.get('name')?.toString().trim();
 		const description = formData.get('description')?.toString() || null;
+		const show_to_candidate = formData.get('show_to_candidate') === 'true';
 
 		if (!name) {
 			setFlash({ type: 'error', message: `${term('tag_type')} name is required.` }, cookies);
@@ -83,7 +84,12 @@ export const actions: Actions = {
 				'Content-Type': 'application/json',
 				Authorization: `Bearer ${token}`
 			},
-			body: JSON.stringify({ name, description, organization_id: user.organization_id })
+			body: JSON.stringify({
+				name,
+				description,
+				show_to_candidate,
+				organization_id: user.organization_id
+			})
 		});
 
 		if (!response.ok) {
@@ -105,6 +111,7 @@ export const actions: Actions = {
 		const id = formData.get('id');
 		const name = formData.get('name')?.toString().trim();
 		const description = formData.get('description')?.toString() || null;
+		const show_to_candidate = formData.get('show_to_candidate') === 'true';
 
 		if (!id || !name) {
 			setFlash({ type: 'error', message: `${term('tag_type')} name is required.` }, cookies);
@@ -117,7 +124,12 @@ export const actions: Actions = {
 				'Content-Type': 'application/json',
 				Authorization: `Bearer ${token}`
 			},
-			body: JSON.stringify({ name, description, organization_id: user.organization_id })
+			body: JSON.stringify({
+				name,
+				description,
+				show_to_candidate,
+				organization_id: user.organization_id
+			})
 		});
 
 		if (!response.ok) {

--- a/src/routes/(admin)/tags/+page.svelte
+++ b/src/routes/(admin)/tags/+page.svelte
@@ -36,8 +36,12 @@
 	// Tag Type Dialog state
 	let tagTypeDialogOpen = $state(false);
 	let tagTypeDialogMode: 'create' | 'edit' = $state('create');
-	let editingTagType: { id: number; name: string; description?: string | null } | null =
-		$state(null);
+	let editingTagType: {
+		id: number;
+		name: string;
+		description?: string | null;
+		show_to_candidate?: boolean | null;
+	} | null = $state(null);
 
 	// Tag inline edit state
 	let editingTagId: number | string | null = $state(null);
@@ -66,12 +70,18 @@
 		tagTypeDialogOpen = true;
 	}
 
-	function openEditTagType(tagType: { id: number | string; name: string; description?: string }) {
+	function openEditTagType(tagType: {
+		id: number | string;
+		name: string;
+		description?: string;
+		show_to_candidate?: boolean;
+	}) {
 		tagTypeDialogMode = 'edit';
 		editingTagType = {
 			id: tagType.id as number,
 			name: tagType.name,
-			description: tagType.description
+			description: tagType.description,
+			show_to_candidate: tagType.show_to_candidate
 		};
 		tagTypeDialogOpen = true;
 	}

--- a/src/routes/(admin)/tags/TagTypeCell.svelte
+++ b/src/routes/(admin)/tags/TagTypeCell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Pencil from '@lucide/svelte/icons/pencil';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
+	import Eye from '@lucide/svelte/icons/eye';
 	import { useTerms } from '$lib/nomenclature';
 
 	const term = useTerms();
@@ -16,6 +17,7 @@
 			id: number | string;
 			name: string;
 			description?: string;
+			show_to_candidate?: boolean;
 			tags?: { id: number | string; name: string }[];
 		};
 		canEdit?: boolean;
@@ -32,6 +34,14 @@
 			{#if tagType.tags !== undefined}
 				<span class="ml-1 text-muted-foreground font-normal">
 					({tagType.tags.length})
+				</span>
+			{/if}
+			{#if tagType.show_to_candidate}
+				<span
+					class="ml-1 inline-flex align-middle text-muted-foreground"
+					title="Visible to candidates"
+				>
+					<Eye class="h-3.5 w-3.5" />
 				</span>
 			{/if}
 		</div>

--- a/src/routes/(admin)/tags/TagTypeCell.svelte.test.ts
+++ b/src/routes/(admin)/tags/TagTypeCell.svelte.test.ts
@@ -24,7 +24,13 @@ const defaultTagType = {
 
 function renderCell(
 	props: {
-		tagType?: { id: number | string; name: string; description?: string; tags?: { id: number | string; name: string }[] };
+		tagType?: {
+			id: number | string;
+			name: string;
+			description?: string;
+			show_to_candidate?: boolean;
+			tags?: { id: number | string; name: string }[];
+		};
 		canEdit?: boolean;
 		canDelete?: boolean;
 		onEdit?: (tagType: { id: number | string; name: string; description?: string }) => void;
@@ -97,6 +103,23 @@ describe('TagTypeCell', () => {
 		it('does not render a description element when description is an empty string', () => {
 			renderCell({ tagType: { id: 1, name: 'Difficulty', description: '' } });
 			expect(document.querySelector('.text-sm')).toBeNull();
+		});
+	});
+
+	describe('show_to_candidate indicator', () => {
+		it('shows "Visible to candidates" eye icon when show_to_candidate is true', () => {
+			renderCell({ tagType: { ...defaultTagType, show_to_candidate: true } });
+			expect(screen.getByTitle('Visible to candidates')).toBeInTheDocument();
+		});
+
+		it('does not show the indicator when show_to_candidate is false', () => {
+			renderCell({ tagType: { ...defaultTagType, show_to_candidate: false } });
+			expect(screen.queryByTitle('Visible to candidates')).not.toBeInTheDocument();
+		});
+
+		it('does not show the indicator when show_to_candidate is undefined', () => {
+			renderCell({ tagType: { id: 1, name: 'Difficulty' } });
+			expect(screen.queryByTitle('Visible to candidates')).not.toBeInTheDocument();
 		});
 	});
 

--- a/src/routes/(admin)/tags/TagTypeDialog.svelte
+++ b/src/routes/(admin)/tags/TagTypeDialog.svelte
@@ -4,6 +4,9 @@
 	import Textarea from '$lib/components/ui/textarea/textarea.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import Label from '$lib/components/ui/label/label.svelte';
+	import Switch from '$lib/components/ui/switch/switch.svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import Info from '@lucide/svelte/icons/info';
 	import { enhance } from '$app/forms';
 	import { useTerms } from '$lib/nomenclature';
 
@@ -16,11 +19,17 @@
 	}: {
 		open: boolean;
 		mode: 'create' | 'edit';
-		tagType: { id: number; name: string; description?: string | null } | null;
+		tagType: {
+			id: number;
+			name: string;
+			description?: string | null;
+			show_to_candidate?: boolean | null;
+		} | null;
 	} = $props();
 
 	let name = $state('');
 	let description = $state('');
+	let showToCandidate = $state(false);
 	let submitting = $state(false);
 
 	// Reset form when dialog opens
@@ -29,9 +38,11 @@
 			if (mode === 'edit' && tagType) {
 				name = tagType.name;
 				description = tagType.description || '';
+				showToCandidate = tagType.show_to_candidate ?? false;
 			} else {
 				name = '';
 				description = '';
+				showToCandidate = false;
 			}
 		}
 	});
@@ -64,6 +75,7 @@
 			{#if mode === 'edit' && tagType}
 				<input type="hidden" name="id" value={tagType.id} />
 			{/if}
+			<input type="hidden" name="show_to_candidate" value={showToCandidate ? 'true' : 'false'} />
 			<div class="flex flex-col gap-5 pt-2 pb-2">
 				<div class="flex flex-col gap-3">
 					<Label for="tag-type-name">Name</Label>
@@ -84,6 +96,30 @@
 						placeholder="Optional — helps others understand what this tag type is for"
 						rows={3}
 					/>
+				</div>
+				<div class="flex items-center gap-3">
+					<Switch id="tag-type-show-to-candidate" bind:checked={showToCandidate} />
+					<Label for="tag-type-show-to-candidate" class="flex cursor-pointer items-center gap-1.5">
+						Make {term('tag', 'lower')} visible to candidates
+						<Tooltip.Provider>
+							<Tooltip.Root>
+								<Tooltip.Trigger>
+									<Info class="h-3.5 w-3.5 text-muted-foreground" />
+								</Tooltip.Trigger>
+								<Tooltip.Content
+									class="border-border bg-popover text-popover-foreground max-w-xs rounded-md border p-3 text-xs shadow-lg/20"
+									side="top"
+								>
+									<p>
+										Candidates will be able to see {term('tags', 'lower')} of this {term(
+											'tag_type',
+											'lower'
+										)} during answer review
+									</p>
+								</Tooltip.Content>
+							</Tooltip.Root>
+						</Tooltip.Provider>
+					</Label>
 				</div>
 				<Button type="submit" class="mt-4 w-full" disabled={!name.trim() || submitting}>
 					{buttonText}

--- a/src/routes/(admin)/tags/TagTypeDialog.svelte.test.ts
+++ b/src/routes/(admin)/tags/TagTypeDialog.svelte.test.ts
@@ -4,9 +4,10 @@ import { render, screen, fireEvent, within } from '@testing-library/svelte';
 import TagTypeDialog from './TagTypeDialog.svelte';
 
 vi.mock('$lib/nomenclature', () => ({
-	useTerms: () => (key: string) => {
-		const map: Record<string, string> = { tag_type: 'Tag Type' };
-		return map[key] ?? key;
+	useTerms: () => (key: string, modifier?: string) => {
+		const map: Record<string, string> = { tag_type: 'Tag Type', tag: 'Tag', tags: 'Tags' };
+		const val = map[key] ?? key;
+		return modifier === 'lower' ? val.toLowerCase() : val;
 	}
 }));
 
@@ -14,7 +15,12 @@ vi.mock('$app/forms', () => ({
 	enhance: vi.fn(() => ({ destroy: vi.fn() }))
 }));
 
-const defaultTagType = { id: 42, name: 'Difficulty Level', description: 'How hard the question is' };
+const defaultTagType = {
+	id: 42,
+	name: 'Difficulty Level',
+	description: 'How hard the question is',
+	show_to_candidate: true
+};
 
 function renderDialog(
 	props: { open?: boolean; mode?: 'create' | 'edit'; tagType?: typeof defaultTagType | null } = {}
@@ -254,6 +260,78 @@ describe('TagTypeDialog', () => {
 		});
 	});
 
+	describe('Show to candidate toggle', () => {
+		it('renders the label text', async () => {
+			renderDialog({ mode: 'create' });
+			await screen.findByRole('dialog');
+			expect(screen.getByText('Make tag visible to candidates')).toBeInTheDocument();
+		});
+
+		it('renders a tooltip trigger next to the label', async () => {
+			renderDialog({ mode: 'create' });
+			await screen.findByRole('dialog');
+			const dialog = screen.getByRole('dialog');
+			expect(dialog.querySelector('[data-slot="tooltip-trigger"]')).toBeInTheDocument();
+		});
+
+		it('renders unchecked by default in create mode', async () => {
+			renderDialog({ mode: 'create' });
+			await screen.findByRole('dialog');
+			expect(screen.getByRole('switch')).not.toBeChecked();
+		});
+
+		it('sets the hidden input to "false" by default in create mode', async () => {
+			renderDialog({ mode: 'create' });
+			await screen.findByRole('dialog');
+			const form = screen.getByRole('dialog').querySelector('form');
+			const hiddenInput = form!.querySelector(
+				'input[name="show_to_candidate"]'
+			) as HTMLInputElement;
+			expect(hiddenInput.value).toBe('false');
+		});
+
+		it('is checked when tagType.show_to_candidate is true in edit mode', async () => {
+			renderDialog({ mode: 'edit', tagType: defaultTagType });
+			await screen.findByRole('dialog');
+			expect(screen.getByRole('switch')).toBeChecked();
+		});
+
+		it('is unchecked when tagType.show_to_candidate is false in edit mode', async () => {
+			renderDialog({ mode: 'edit', tagType: { ...defaultTagType, show_to_candidate: false } });
+			await screen.findByRole('dialog');
+			expect(screen.getByRole('switch')).not.toBeChecked();
+		});
+
+		it('is unchecked when tagType.show_to_candidate is undefined in edit mode', async () => {
+			const { show_to_candidate, ...tagTypeWithoutFlag } = defaultTagType;
+			renderDialog({ mode: 'edit', tagType: tagTypeWithoutFlag });
+			await screen.findByRole('dialog');
+			expect(screen.getByRole('switch')).not.toBeChecked();
+		});
+
+		it('updates the hidden input value to "true" when toggled on', async () => {
+			renderDialog({ mode: 'create' });
+			await screen.findByRole('dialog');
+			await fireEvent.click(screen.getByRole('switch'));
+			const form = screen.getByRole('dialog').querySelector('form');
+			const hiddenInput = form!.querySelector(
+				'input[name="show_to_candidate"]'
+			) as HTMLInputElement;
+			expect(hiddenInput.value).toBe('true');
+		});
+
+		it('updates the hidden input value back to "false" when toggled off again', async () => {
+			renderDialog({ mode: 'edit', tagType: defaultTagType });
+			await screen.findByRole('dialog');
+			await fireEvent.click(screen.getByRole('switch'));
+			const form = screen.getByRole('dialog').querySelector('form');
+			const hiddenInput = form!.querySelector(
+				'input[name="show_to_candidate"]'
+			) as HTMLInputElement;
+			expect(hiddenInput.value).toBe('false');
+		});
+	});
+
 	describe('Dialog resets on reopen', () => {
 		it('resets name and description to empty when reopening in create mode', async () => {
 			const { rerender } = renderDialog({ mode: 'create', open: false });
@@ -269,6 +347,14 @@ describe('TagTypeDialog', () => {
 			await screen.findByRole('dialog');
 			expect(screen.getByLabelText('Name')).toHaveValue('Difficulty Level');
 			expect(screen.getByLabelText('Description')).toHaveValue('How hard the question is');
+			expect(screen.getByRole('switch')).toBeChecked();
+		});
+
+		it('resets show_to_candidate to unchecked when reopening in create mode', async () => {
+			const { rerender } = renderDialog({ mode: 'edit', tagType: defaultTagType, open: false });
+			await rerender({ open: true, mode: 'create', tagType: null });
+			await screen.findByRole('dialog');
+			expect(screen.getByRole('switch')).not.toBeChecked();
 		});
 	});
 

--- a/src/routes/(admin)/tags/columns.ts
+++ b/src/routes/(admin)/tags/columns.ts
@@ -9,6 +9,7 @@ export interface TagType {
 	id: number | string;
 	name: string;
 	description?: string;
+	show_to_candidate?: boolean;
 	tags: { id: number | string; name: string }[];
 }
 

--- a/src/routes/(admin)/tags/page.server.test.ts
+++ b/src/routes/(admin)/tags/page.server.test.ts
@@ -138,7 +138,11 @@ describe('actions', () => {
 			(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
 			await actions.createTagType({
-				request: mockRequest({ name: 'Difficulty', description: 'How hard' }),
+				request: mockRequest({
+					name: 'Difficulty',
+					description: 'How hard',
+					show_to_candidate: 'true'
+				}),
 				cookies: {}
 			});
 
@@ -153,7 +157,21 @@ describe('actions', () => {
 			const body = JSON.parse(fetchCall[1].body);
 			expect(body.name).toBe('Difficulty');
 			expect(body.description).toBe('How hard');
+			expect(body.show_to_candidate).toBe(true);
 			expect(body.organization_id).toBe(10);
+		});
+
+		it('defaults show_to_candidate to false when not provided', async () => {
+			(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+			await actions.createTagType({
+				request: mockRequest({ name: 'Difficulty' }),
+				cookies: {}
+			});
+
+			const fetchCall = (global.fetch as any).mock.calls[0];
+			const body = JSON.parse(fetchCall[1].body);
+			expect(body.show_to_candidate).toBe(false);
 		});
 
 		it('returns fail(400) when name is empty', async () => {
@@ -191,7 +209,12 @@ describe('actions', () => {
 			(global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
 			await actions.updateTagType({
-				request: mockRequest({ id: '5', name: 'Updated', description: 'New desc' }),
+				request: mockRequest({
+					id: '5',
+					name: 'Updated',
+					description: 'New desc',
+					show_to_candidate: 'true'
+				}),
 				cookies: {}
 			});
 
@@ -203,6 +226,8 @@ describe('actions', () => {
 			const fetchCall = (global.fetch as any).mock.calls[0];
 			expect(fetchCall[0]).toBe('http://fake-backend.com/tagtype/5');
 			expect(fetchCall[1].method).toBe('PUT');
+			const body = JSON.parse(fetchCall[1].body);
+			expect(body.show_to_candidate).toBe(true);
 		});
 
 		it('returns fail(400) when name is missing', async () => {


### PR DESCRIPTION
Fixes #597 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to control whether tag types are visible to candidates.
  * Tag type creation and editing now support enabling or disabling candidate visibility.
  * Added a visibility indicator and tooltip for tag types shown to candidates.
  * Visibility defaults to off when not specified.

* **Tests**
  * Added coverage for visibility controls, indicators, defaults, toggling, and saved values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->